### PR TITLE
Updated base fields and MarcError

### DIFF
--- a/record_validator/base_fields.py
+++ b/record_validator/base_fields.py
@@ -74,7 +74,7 @@ def parse_input(input: Union[MarcField, Dict[str, Any]], model: Any) -> Dict[str
 class BaseControlField(BaseModel):
     model_config = ConfigDict(populate_by_name=True, loc_by_alias=False, extra="forbid")
 
-    tag: Annotated[str, Field(pattern=r"^00[0-9]$")]
+    tag: Annotated[str, Field(pattern=r"00[1-9]")]
     value: str
 
     @model_validator(mode="before")
@@ -105,7 +105,7 @@ class BaseDataField(BaseModel):
         populate_by_name=True, loc_by_alias=False, alias_generator=get_alias
     )
 
-    tag: Annotated[str, Field(max_length=3, min_length=3, exclude=True)]
+    tag: Annotated[str, Field(pattern=r"0[1-9]\d|[1-9]\d\d", exclude=True)]
     ind1: Union[Literal["", " "], Annotated[str, Field(pattern=r"^\d$")]]
     ind2: Union[Literal["", " "], Annotated[str, Field(pattern=r"^\d$")]]
     subfields: List[Dict[str, str]]

--- a/record_validator/field_models.py
+++ b/record_validator/field_models.py
@@ -201,9 +201,9 @@ class OtherDataField(BaseDataField):
     tag: Annotated[
         str,
         Field(
-            pattern=r"^0[1-9]\d$|^[1-7]\d\d$|^(80[0-9])$|^(8[1-4][0-9])$|^(85[0-1])$|^(85[3-9])$|^(8[6-9][0-9])$|^(90[2-9])$|^(9[1-4][0-9])$|^(95[0-8])$|^(9[6-7][0-9])$|^(98[1-9])$",  # noqa 501
+            pattern=r"0[1-9]{2}|0[1-46-9]0|^[1-7]\d\d|8[0-46-9]\d|85[013-9]|90[02-9]|9[168][1-9]|94[0-8]|9[23579]\d",
         ),
     ]
-    ind1: Union[Literal[""], Annotated[str, Field(max_length=1, min_length=1)]]
-    ind2: Union[Literal[""], Annotated[str, Field(max_length=1, min_length=1)]]
+    ind1: Union[Literal["", " "], Annotated[str, Field(max_length=1, min_length=1)]]
+    ind2: Union[Literal["", " "], Annotated[str, Field(max_length=1, min_length=1)]]
     subfields: List[Any]

--- a/record_validator/field_models.py
+++ b/record_validator/field_models.py
@@ -201,7 +201,7 @@ class OtherDataField(BaseDataField):
     tag: Annotated[
         str,
         Field(
-            pattern=r"0[1-9]{2}|0[1-46-9]0|^[1-7]\d\d|8[0-46-9]\d|85[013-9]|90[02-9]|9[168][1-9]|94[0-8]|9[23579]\d",
+            pattern=r"0[1-9]{2}|0[1-46-9]0|^[1-7]\d\d|8[0-46-9]\d|85[013-9]|90[02-9]|9[168][1-9]|94[0-8]|9[23579]\d",  # noqa: E501
         ),
     ]
     ind1: Union[Literal["", " "], Annotated[str, Field(max_length=1, min_length=1)]]

--- a/record_validator/marc_errors.py
+++ b/record_validator/marc_errors.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Tuple, Union
+from typing import Any, Tuple, Union
 from pydantic_core import ErrorDetails
 
 
@@ -48,13 +48,12 @@ class MarcError:
 
     def __init__(self, error: ErrorDetails):
         self.original_error = error
-        self.type = error.get("type")
-        self.input = self._get_input()
-        self.loc = self._get_loc()
-        self.msg = error.get("msg", None)
-        self.ctx = error.get("ctx", None)
-        self.url = error.get("url", None)
-        self.loc_marc = self._loc2marc()
+        self.type: str = error["type"]
+        self.ctx: Union[dict[str, Any], None] = error.get("ctx", None)
+        self.input: Union[str, tuple] = self._get_input()
+        self.loc: Union[str, tuple] = self._get_loc()
+        self.loc_marc: Union[str, tuple] = self._loc2marc()
+        self.msg: Union[str, None] = error.get("msg", None)
 
     def _get_input(self):
         if self.type == "order_item_mismatch":

--- a/tests/test_base_fields.py
+++ b/tests/test_base_fields.py
@@ -138,6 +138,22 @@ def test_BaseControlField_invalid_value():
     assert e.value.errors()[0]["type"] == "string_type"
 
 
+def test_BaseControlField_invalid_tag_literal():
+    with pytest.raises(ValidationError) as e:
+        BaseControlField(tag="010", ind1=" ", ind2=" ", subfields=[{"a": "foo"}])
+    error_types = [error["type"] for error in e.value.errors()]
+    assert len(e.value.errors()) == 5
+    assert sorted(error_types) == sorted(
+        [
+            "string_pattern_mismatch",
+            "extra_forbidden",
+            "extra_forbidden",
+            "extra_forbidden",
+            "missing",
+        ]
+    )
+
+
 @pytest.mark.parametrize(
     "input",
     [
@@ -204,7 +220,7 @@ def test_BaseDataField_invalid_tag():
         BaseDataField(tag="0000", ind1=" ", ind2=" ", subfields=[{"a": "F00"}])
     assert len(e.value.errors()) == 1
     assert e.value.errors()[0]["loc"] == ("tag",)
-    assert e.value.errors()[0]["type"] == "string_too_long"
+    assert e.value.errors()[0]["type"] == "string_pattern_mismatch"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_marc_errors.py
+++ b/tests/test_marc_errors.py
@@ -143,7 +143,6 @@ def test_MarcError_order_item_mismatch(stub_record):
     )
     assert sorted(error.input) == sorted(("MAB", "rcmf2", "55"))
     assert error.ctx is None
-    assert error.url is None
     assert error.type == "order_item_mismatch"
     assert (
         "Invalid combination of item_type, order_location and item_location:"


### PR DESCRIPTION
Fixed:
 - regex for `OtherDataField` tag
 - indicators in `OtherDataField`
 - `BaseControlField` and `BaseDataField`

Added:
 - type annotations for `MarcError` variables

Removed:
 - `MarcError.url` attribute