### PR TITLE
Fixing marcerror output

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+per-file-ignores =
+    tests/*:E501

--- a/record_validator/field_models.py
+++ b/record_validator/field_models.py
@@ -14,6 +14,7 @@ class BibCallNo(BaseDataField):
         Field(
             pattern=r"^ReCAP 23-\d{6}$|^ReCAP 24-\d{6}$|^ReCAP 25-\d{6}$",
             exclude=True,
+            examples=["ReCAP 23-000001", "ReCAP 24-100001", "ReCAP 25-222000"],
         ),
     ]
 
@@ -43,6 +44,7 @@ class InvoiceField(BaseDataField):
         str,
         Field(
             pattern=r"^\d{6}$",
+            examples=["240101", "230202"],
             exclude=True,
         ),
     ]
@@ -51,6 +53,7 @@ class InvoiceField(BaseDataField):
         Field(
             pattern=r"^\d{3,}$",
             exclude=True,
+            examples=["100", "200"],
         ),
     ]
     invoice_shipping: Annotated[
@@ -58,6 +61,7 @@ class InvoiceField(BaseDataField):
         Field(
             pattern=r"^\d{1,}$",
             exclude=True,
+            examples=["1", "20"],
         ),
     ]
     invoice_tax: Annotated[
@@ -65,6 +69,7 @@ class InvoiceField(BaseDataField):
         Field(
             pattern=r"^\d{1,}$",
             exclude=True,
+            examples=["1", "20"],
         ),
     ]
     invoice_net_price: Annotated[
@@ -72,6 +77,7 @@ class InvoiceField(BaseDataField):
         Field(
             pattern=r"^\d{3,}$",
             exclude=True,
+            examples=["100", "200"],
         ),
     ]
     invoice_number: Annotated[str, Field(exclude=True)]
@@ -80,6 +86,7 @@ class InvoiceField(BaseDataField):
         Field(
             pattern=r"^\d{1,}$",
             exclude=True,
+            examples=["1", "20", "4"],
         ),
     ]
 
@@ -93,6 +100,7 @@ class ItemField(BaseDataField):
         str,
         Field(
             pattern=r"^ReCAP 23-\d{6}$|^ReCAP 24-\d{6}$|^ReCAP 25-\d{6}$",
+            examples=["ReCAP 23-000001", "ReCAP 24-100001", "ReCAP 25-222000"],
             exclude=True,
         ),
     ]
@@ -105,6 +113,7 @@ class ItemField(BaseDataField):
         str,
         Field(
             pattern=r"^33433[0-9]{9}$",
+            examples=["33433123456789", "33433111111111"],
             exclude=True,
         ),
     ]
@@ -128,7 +137,11 @@ class ItemField(BaseDataField):
     message: Optional[Annotated[str, Field(exclude=True)]] = None
     item_price: Annotated[
         str,
-        Field(pattern=r"^\d{1,}\.\d{2}$", exclude=True),
+        Field(
+            pattern=r"^\d{1,}\.\d{2}$",
+            exclude=True,
+            examples=["1.00", "0.00"],
+        ),
     ]
     item_type: Annotated[
         Optional[Literal["2", "55"]], Field(exclude=True, default=None)
@@ -149,7 +162,7 @@ class LCClass(BaseDataField):
     ind1: Literal[" ", "", "0", "1"]
     ind2: Literal["0", "4"]
     subfields: List[Dict[str, str]]
-    lcc: Annotated[str, Field(exclude=True)]
+    lcc: Annotated[str, Field(exclude=True, examples=["PJ7962.H565", "DK504.932.R87"])]
 
     @model_validator(mode="after")
     def validate_indicator_pair(self) -> "LCClass":
@@ -183,6 +196,7 @@ class OrderField(BaseDataField):
         Field(
             pattern=r"^\d{3,}$",
             exclude=True,
+            examples=["100", "200"],
         ),
     ]
     order_location: Annotated[
@@ -202,6 +216,7 @@ class OtherDataField(BaseDataField):
         str,
         Field(
             pattern=r"0[1-9]{2}|0[1-46-9]0|^[1-7]\d\d|8[0-46-9]\d|85[013-9]|90[02-9]|9[168][1-9]|94[0-8]|9[23579]\d",  # noqa: E501
+            examples=["100", "710", "650", "245"],
         ),
     ]
     ind1: Union[Literal["", " "], Annotated[str, Field(max_length=1, min_length=1)]]

--- a/record_validator/field_models.py
+++ b/record_validator/field_models.py
@@ -30,9 +30,72 @@ class BibVendorCode(BaseDataField):
     ]
 
 
-class ControlField(BaseControlField):
-    tag: Literal["001", "003", "005", "006", "007", "008"]
-    value: str
+class ControlField001(BaseControlField):
+    tag: Annotated[Literal["001"], Field(alias="001")]
+    value: Annotated[
+        str,
+        Field(examples=["ocn123456789", "ocm123456789"]),
+    ]
+
+
+class ControlField003(BaseControlField):
+    tag: Annotated[Literal["003"], Field(alias="003")]
+    value: Annotated[
+        str,
+        Field(examples=["OCoLC", "DLC"]),
+    ]
+
+
+class ControlField005(BaseControlField):
+    tag: Annotated[Literal["005"], Field(alias="005")]
+    value: Annotated[
+        str,
+        Field(pattern=r"^\d{14}\.\d$", examples=["20240101125000.0"]),
+    ]
+
+
+class ControlField006(BaseControlField):
+    tag: Annotated[Literal["006"], Field(alias="006")]
+    value: Annotated[
+        str,
+        Field(pattern=r"^[A-z0-9|\\ ]{1,18}$", examples=["b|||||||||||||||||"]),
+    ]
+
+
+class ControlField007(BaseControlField):
+    tag: Annotated[Literal["007"], Field(alias="007")]
+    value: Annotated[
+        str,
+        Field(pattern=r"^[A-z0-9|\\ ]{2,23}$", examples=["cr |||||||||||"]),
+    ]
+
+
+class ControlField008(BaseControlField):
+    tag: Annotated[Literal["008"], Field(alias="008")]
+    value: Annotated[
+        str,
+        Field(
+            pattern=r"^[a-z0-9|\\ ]{40}$",
+            examples=["210505s2021    nyu           000 0 eng d"],
+        ),
+    ]
+
+
+# class ControlField(BaseControlField):
+#     tag: Literal["001", "003", "005", "006", "007", "008"]
+#     value: Annotated[
+#         str,
+#         Field(
+#             examples=[
+#                 {"001": "ocn123456789"},
+#                 {"003": "OCoLC"},
+#                 {"005": "20210505123456"},
+#                 {"006": "m d"},
+#                 {"007": "cr"},
+#                 {"008": "210505s2021    nyu           000 0 eng d"},
+#             ]
+#         ),
+#     ]
 
 
 class InvoiceField(BaseDataField):
@@ -80,7 +143,9 @@ class InvoiceField(BaseDataField):
             examples=["100", "200"],
         ),
     ]
-    invoice_number: Annotated[str, Field(exclude=True)]
+    invoice_number: Annotated[
+        str, Field(exclude=True, examples=["20051330", "20051331"])
+    ]
     invoice_copies: Annotated[
         str,
         Field(
@@ -104,7 +169,9 @@ class ItemField(BaseDataField):
             exclude=True,
         ),
     ]
-    item_volume: Optional[Annotated[str, Field(exclude=True)]] = None
+    item_volume: Optional[
+        Annotated[str, Field(exclude=True, examples=["v. 1", "v. 10"])]
+    ] = None
     item_agency: Annotated[
         Literal["43"],
         Field(exclude=True),
@@ -207,7 +274,7 @@ class OrderField(BaseDataField):
     ]
     order_fund: Annotated[
         str,
-        Field(exclude=True),
+        Field(exclude=True, examples=["41901apprv"]),
     ]
 
 

--- a/record_validator/marc_errors.py
+++ b/record_validator/marc_errors.py
@@ -163,20 +163,9 @@ class MarcValidationError:
 
     def to_dict(self):
         out_dict = {
-            "valid": False,
-            "error_count": 0,
-            "missing_field_count": len(self.missing_fields),
             "missing_fields": [i.loc_marc for i in self.missing_fields],
-            "extra_field_count": len(self.extra_fields),
             "extra_fields": [i.loc_marc for i in self.extra_fields],
-            "invalid_field_count": len(self.invalid_fields),
             "invalid_fields": self.invalid_fields,
             "order_item_mismatches": self.order_item_mismatches,
         }
-        out_dict["error_count"] = (
-            out_dict["missing_field_count"]
-            + out_dict["extra_field_count"]
-            + out_dict["invalid_field_count"]
-        )
-        out_dict["error_count"] += len(self.order_item_mismatches)
         return out_dict

--- a/record_validator/marc_models.py
+++ b/record_validator/marc_models.py
@@ -3,7 +3,8 @@
 from typing import Annotated, Dict, List, Union
 from pydantic import BaseModel, Field, ConfigDict
 from pymarc import Field as MarcField
-from pydantic.functional_validators import AfterValidator
+from pymarc import Leader
+from pydantic.functional_validators import AfterValidator, field_validator
 from record_validator.parsers import validate_fields
 
 
@@ -32,17 +33,11 @@ class MonographRecord(BaseModel):
         ],
         AfterValidator(validate_fields),
     ]
-    # material_type: Annotated[
-    #     Union[
-    #         Literal["monograph"],
-    #         Literal[
-    #             "catalogue_raissonne",
-    #             "dance",
-    #             "multipart",
-    #             "pamphlet",
-    #             "non-standard_binding_packaging",
-    #         ],
-    #     ],
-    #     Field(exclude=True),
-    #     BeforeValidator(get_material_type),
-    # ]
+
+    @field_validator("leader", mode="before")
+    @classmethod
+    def validate_leader(cls, leader: Union[str, Leader]) -> str:
+        if isinstance(leader, str):
+            return leader
+        else:
+            return str(leader)

--- a/record_validator/parsers.py
+++ b/record_validator/parsers.py
@@ -5,7 +5,12 @@ from pydantic_core import PydanticCustomError, ValidationError, InitErrorDetails
 from record_validator.field_models import (
     BibCallNo,
     BibVendorCode,
-    ControlField,
+    ControlField001,
+    ControlField003,
+    ControlField005,
+    ControlField006,
+    ControlField007,
+    ControlField008,
     InvoiceField,
     ItemField,
     LCClass,
@@ -40,11 +45,55 @@ VALID_ORDER_ITEMS = [
 ]
 
 
+def get_examples_from_schema(field: tuple) -> Union[List[str], None]:
+    if len(field) == 2:
+        model = field[0]
+        model_field = field[1]
+        by_alias = False
+    elif field[0] == "fields" and field[2] == "subfields":
+        model = field[1]
+        model_field = f"subfields.{field[4]}"
+        by_alias = True
+    else:
+        model = field[1]
+        model_field = field[2]
+        by_alias = False
+
+    match model:
+        case "001":
+            schema = ControlField001.model_json_schema(by_alias=by_alias)
+        case "003":
+            schema = ControlField003.model_json_schema(by_alias=by_alias)
+        case "005":
+            schema = ControlField005.model_json_schema(by_alias=by_alias)
+        case "006":
+            schema = ControlField006.model_json_schema(by_alias=by_alias)
+        case "007":
+            schema = ControlField007.model_json_schema(by_alias=by_alias)
+        case "008":
+            schema = ControlField008.model_json_schema(by_alias=by_alias)
+        case "050":
+            schema = LCClass.model_json_schema(by_alias=by_alias)
+        case "852":
+            schema = BibCallNo.model_json_schema(by_alias=by_alias)
+        case "980":
+            schema = InvoiceField.model_json_schema(by_alias=by_alias)
+        case "949":
+            schema = ItemField.model_json_schema(by_alias=by_alias)
+
+        case "960":
+            schema = OrderField.model_json_schema(by_alias=by_alias)
+
+        case _:
+            return None
+    return schema["properties"][model_field]["examples"]
+
+
 def get_field_tag(field: Union[MarcField, dict]) -> str:
     tag = field.tag if isinstance(field, MarcField) else list(field.keys())[0]
-    if tag in CONTROL_FIELDS:
-        return "control_field"
-    elif tag in REQUIRED_FIELDS:
+    # if tag in CONTROL_FIELDS:
+    #     return "control_field"
+    if tag in REQUIRED_FIELDS or tag in CONTROL_FIELDS:
         return tag
     else:
         return "data_field"
@@ -156,7 +205,12 @@ def validate_field_values(fields: list) -> list:
                 Annotated[LibraryField, Tag("910")],
                 Annotated[OrderField, Tag("960")],
                 Annotated[OtherDataField, Tag("data_field")],
-                Annotated[ControlField, Tag("control_field")],
+                Annotated[ControlField001, Tag("001")],
+                Annotated[ControlField003, Tag("003")],
+                Annotated[ControlField005, Tag("005")],
+                Annotated[ControlField006, Tag("006")],
+                Annotated[ControlField007, Tag("007")],
+                Annotated[ControlField008, Tag("008")],
             ],
             Discriminator(get_field_tag),
         ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,7 +80,7 @@ def stub_invoice():
 @pytest.fixture
 def stub_record(stub_item, stub_order, stub_invoice):
     bib = Record()
-    bib.leader = "00820cam a22001935i 4500"
+    bib.leader = "00454cam a22001575i 4500"
     bib.add_field(MarcField(tag="008", data="190306s2017    ht a   j      000 1 hat d"))
     bib.add_field(MarcField(tag="001", data="on1381158740"))
     bib.add_field(

--- a/tests/test_field_models.py
+++ b/tests/test_field_models.py
@@ -4,7 +4,12 @@ from pymarc import Field as MarcField
 from record_validator.field_models import (
     BibCallNo,
     BibVendorCode,
-    ControlField,
+    ControlField001,
+    ControlField003,
+    ControlField005,
+    ControlField006,
+    ControlField007,
+    ControlField008,
     InvoiceField,
     ItemField,
     LCClass,
@@ -232,38 +237,17 @@ def test_BibVendorCode_invalid_code_value(field_value):
     assert len(e.value.errors()) == 1
 
 
-@pytest.mark.parametrize(
-    "tag, value",
-    [
-        ("001", "ocn123456789"),
-        ("003", "foo"),
-        ("005", "20240413112604.0"),
-        ("006", "bar"),
-        ("007", "baz"),
-        ("008", "190306s2017    ht a   j      000 1 hat d"),
-    ],
-)
-def test_ControlField_valid(tag, value):
-    model = ControlField(tag=tag, value=value)
-    assert model.model_dump(by_alias=True) == {tag: value}
+def test_ControlField001_valid():
+    model = ControlField001(tag="001", value="ocn123456789")
+    assert model.model_dump(by_alias=True) == {"001": "ocn123456789"}
 
 
-def test_ControlField_valid_from_field(stub_record):
-    field = stub_record.get_fields("008")[0]
-    assert isinstance(field, MarcField)
-    model = ControlField.model_validate(field, from_attributes=True)
+def test_ControlField001_valid_from_field():
+    field = MarcField(tag="001", data="ocn123456789")
+    model = ControlField001.model_validate(field, from_attributes=True)
     assert model.model_dump(by_alias=True) == {
-        "008": "190306s2017    ht a   j      000 1 hat d",
+        "001": "ocn123456789",
     }
-
-
-@pytest.mark.parametrize("tag", ["foo", "bar", "baz"])
-def test_ControlField_invalid_code_type(tag):
-    with pytest.raises(ValidationError) as e:
-        ControlField(tag=tag, value="foo")
-    assert e.value.errors()[0]["type"] == "literal_error"
-    assert e.value.errors()[0]["loc"] == ("tag",)
-    assert len(e.value.errors()) == 1
 
 
 @pytest.mark.parametrize(
@@ -275,22 +259,168 @@ def test_ControlField_invalid_code_type(tag):
         [],
     ],
 )
-def test_ControlField_invalid_code_value(field_value):
+def test_ControlField001_invalid_code_value(field_value):
     with pytest.raises(ValidationError) as e:
-        ControlField(tag="001", value=field_value)
+        ControlField001(tag="001", value=field_value)
     assert e.value.errors()[0]["type"] == "string_type"
+    assert e.value.errors()[0]["loc"] == ("value",)
     assert len(e.value.errors()) == 1
+
+
+def test_ControlField003_valid():
+    model = ControlField003(tag="003", value="OCoLC")
+    assert model.model_dump(by_alias=True) == {"003": "OCoLC"}
+
+
+def test_ControlField003_valid_from_field():
+    field = MarcField(tag="003", data="OCoLC")
+    model = ControlField003.model_validate(field, from_attributes=True)
+    assert model.model_dump(by_alias=True) == {
+        "003": "OCoLC",
+    }
 
 
 @pytest.mark.parametrize(
-    "tag",
-    ["020", "050", "650", "700", "852"],
+    "field_value",
+    [
+        1,
+        1.0,
+        None,
+        [],
+    ],
 )
-def test_ControlField_invalid_code_literal(tag):
+def test_ControlField003_invalid_code_value(field_value):
     with pytest.raises(ValidationError) as e:
-        ControlField(tag=tag, value="foo")
-    assert e.value.errors()[0]["type"] == "literal_error"
+        ControlField003(tag="003", value=field_value)
+    assert e.value.errors()[0]["type"] == "string_type"
+    assert e.value.errors()[0]["loc"] == ("value",)
     assert len(e.value.errors()) == 1
+
+
+def test_ControlField005_valid():
+    model = ControlField005(tag="005", value="20241111111111.0")
+    assert model.model_dump(by_alias=True) == {"005": "20241111111111.0"}
+
+
+def test_ControlField005_valid_from_field():
+    field = MarcField(tag="005", data="20241111111111.0")
+    model = ControlField005.model_validate(field, from_attributes=True)
+    assert model.model_dump(by_alias=True) == {"005": "20241111111111.0"}
+
+
+@pytest.mark.parametrize(
+    "field_value",
+    [
+        1,
+        1.0,
+        None,
+        [],
+    ],
+)
+def test_ControlField005_invalid_code_value(field_value):
+    with pytest.raises(ValidationError) as e:
+        ControlField005(tag="005", value=field_value)
+    assert e.value.errors()[0]["type"] == "string_type"
+    assert e.value.errors()[0]["loc"] == ("value",)
+    assert len(e.value.errors()) == 1
+
+
+def test_ControlField006_valid():
+    model = ControlField006(tag="006", value="b     s")
+    assert model.model_dump(by_alias=True) == {"006": "b     s"}
+
+
+def test_ControlField006_valid_from_field():
+    field = MarcField(tag="006", data="b     s")
+    model = ControlField006.model_validate(field, from_attributes=True)
+    assert model.model_dump(by_alias=True) == {"006": "b     s"}
+
+
+@pytest.mark.parametrize(
+    "field_value",
+    [
+        1,
+        1.0,
+        None,
+        [],
+    ],
+)
+def test_ControlField006_invalid_code_value(field_value):
+    with pytest.raises(ValidationError) as e:
+        ControlField006(tag="006", value=field_value)
+    assert e.value.errors()[0]["type"] == "string_type"
+    assert e.value.errors()[0]["loc"] == ("value",)
+    assert len(e.value.errors()) == 1
+
+
+def test_ControlField007_valid():
+    model = ControlField007(tag="007", value="cr |||||||||||")
+    assert model.model_dump(by_alias=True) == {"007": "cr |||||||||||"}
+
+
+def test_ControlField007_valid_from_field():
+    field = MarcField(tag="007", data="cr |||||||||||")
+    model = ControlField007.model_validate(field, from_attributes=True)
+    assert model.model_dump(by_alias=True) == {"007": "cr |||||||||||"}
+
+
+@pytest.mark.parametrize(
+    "field_value",
+    [
+        1,
+        1.0,
+        None,
+        [],
+    ],
+)
+def test_ControlField007_invalid_code_value(field_value):
+    with pytest.raises(ValidationError) as e:
+        ControlField007(tag="007", value=field_value)
+    assert e.value.errors()[0]["type"] == "string_type"
+    assert e.value.errors()[0]["loc"] == ("value",)
+    assert len(e.value.errors()) == 1
+
+
+def test_ControlField008_valid():
+    model = ControlField008(tag="008", value="210505s2021    nyu           000 0 eng d")
+    assert model.model_dump(by_alias=True) == {
+        "008": "210505s2021    nyu           000 0 eng d"
+    }
+
+
+def test_ControlField008_valid_from_field():
+    field = MarcField(tag="008", data="210505s2021    nyu           000 0 eng d")
+    model = ControlField008.model_validate(field, from_attributes=True)
+    assert model.model_dump(by_alias=True) == {
+        "008": "210505s2021    nyu           000 0 eng d"
+    }
+
+
+@pytest.mark.parametrize(
+    "field_value",
+    [
+        1,
+        1.0,
+        None,
+        [],
+    ],
+)
+def test_ControlField008_invalid_code_value(field_value):
+    with pytest.raises(ValidationError) as e:
+        ControlField008(tag="008", value=field_value)
+    assert e.value.errors()[0]["type"] == "string_type"
+    assert e.value.errors()[0]["loc"] == ("value",)
+    assert len(e.value.errors()) == 1
+
+
+def test_ControlField008_invalid_code_literal():
+    with pytest.raises(ValidationError) as e:
+        ControlField008(tag="020", value="foo")
+    assert [i["type"] for i in e.value.errors()] == [
+        "literal_error",
+        "string_pattern_mismatch",
+    ]
+    assert len(e.value.errors()) == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/test_marc_errors.py
+++ b/tests/test_marc_errors.py
@@ -23,7 +23,7 @@ def test_MarcError_string_pattern(stub_record):
     assert error.input == "ReCAP-24-119100"
     assert isinstance(error.ctx, dict)
     assert error.type == "string_pattern_mismatch"
-    assert "String should match pattern " in error.msg
+    assert "String should match pattern" in error.msg
     assert error.loc_marc == "852$h"
 
 
@@ -100,7 +100,7 @@ def test_MarcError_literal(stub_record):
     assert error.input == "foo"
     assert isinstance(error.ctx, dict)
     assert error.type == "literal_error"
-    assert "Input should be " in error.msg
+    assert "Input should be" in error.msg
     assert error.loc_marc == "960$t"
 
 
@@ -125,8 +125,33 @@ def test_MarcError_literal_indicator_error(stub_record):
     assert error.input == "7"
     assert isinstance(error.ctx, dict)
     assert error.type == "literal_error"
-    assert "Input should be " in error.msg
+    assert "Input should be" in error.msg
     assert error.loc_marc == "960ind1"
+
+
+def test_MarcError_extra_fields(stub_record):
+    record_dict = stub_record.as_dict()
+    record_dict["fields"].append(
+        {"003": {"ind1": " ", "ind2": " ", "subfields": [{"a": "foo"}]}}
+    )
+    with pytest.raises(ValidationError) as e:
+        MonographRecord(**record_dict)
+    extra_field_errors = [i for i in e.value.errors() if i["type"] == "extra_forbidden"]
+    string_type_error = [i for i in e.value.errors() if i["type"] == "string_type"]
+    error = MarcError(extra_field_errors[0])
+    assert len(e.value.errors()) == 4
+    assert len(extra_field_errors) == 3
+    assert len(string_type_error) == 1
+    assert error.loc == (
+        "fields",
+        "003",
+        "ind1",
+    )
+    assert error.input == " "
+    assert error.ctx is None
+    assert error.type == "extra_forbidden"
+    assert error.msg == "Extra inputs are not permitted"
+    assert error.loc_marc == "003ind1"
 
 
 def test_MarcError_order_item_mismatch(stub_record):
@@ -152,8 +177,8 @@ def test_MarcError_order_item_mismatch(stub_record):
 
 
 def test_MarcError_string_type(stub_record):
-    stub_record["960"].delete_subfield("u")
-    stub_record["960"].add_subfield("u", 1.00)
+    stub_record["960"].delete_subfield("s")
+    stub_record["960"].add_subfield("s", 1.00)
     with pytest.raises(ValidationError) as e:
         MonographRecord(leader=stub_record.leader, fields=stub_record.fields)
     errors = [MarcError(i) for i in e.value.errors()]
@@ -162,33 +187,89 @@ def test_MarcError_string_type(stub_record):
     errors_loc_marc = [i.loc_marc for i in errors]
     assert len(errors) == 2
     assert sorted(error_locs) == sorted(
-        [("fields", "960", "subfields", 2, "u"), ("fields", "960", "order_fund")]
+        [("fields", "960", "subfields", 0, "s"), ("fields", "960", "order_price")]
     )
     assert all(isinstance(i.input, float) for i in errors)
     assert error_types == ["string_type", "string_type"]
-    assert errors_loc_marc == ["960$u", "960$u"]
+    assert errors_loc_marc == ["960$s", "960$s"]
 
 
-def test_MarcValidationError_multiple_errors(stub_record):
-    stub_record["949"].delete_subfield("h")
-    stub_record["852"].delete_subfield("h")
-    stub_record["852"].add_subfield("h", "ReCAP-24-119100")
+def test_MarcValidationError_literal_error(stub_record):
     stub_record["960"].delete_subfield("t")
     stub_record["960"].add_subfield("t", "foo")
     with pytest.raises(ValidationError) as e:
         MonographRecord(leader=stub_record.leader, fields=stub_record.fields)
     errors = MarcValidationError(e.value.errors()).to_dict()
-    assert errors["missing_field_count"] == 1
+    assert errors["invalid_fields"] == [
+        {
+            "error_type": "Input should be: 'MAB', 'MAF', 'MAG', 'MAL', 'MAP', 'MAS', 'PAD', 'PAH', 'PAM', 'PAT' or 'SC'",
+            "field": "960$t",
+        },
+    ]
+    assert errors["invalid_field_count"] == 1
+    assert errors["error_count"] == 1
+
+
+def test_MarcValidationError_string_type(stub_record):
+    stub_record["960"].delete_subfield("s")
+    stub_record["960"].add_subfield("s", 1.00)
+    with pytest.raises(ValidationError) as e:
+        MonographRecord(leader=stub_record.leader, fields=stub_record.fields)
+    errors = MarcValidationError(e.value.errors()).to_dict()
+    assert errors["invalid_fields"][0] == {
+        "error_type": "Input should be a valid string. Examples: ['100', '200']",
+        "field": "960$s",
+    }
+    assert errors["invalid_fields"][1] == {
+        "error_type": "Input should be a valid string. Examples: ['100', '200']",
+        "field": "960$s",
+    }
     assert errors["invalid_field_count"] == 2
-    assert errors["extra_field_count"] == 0
-    assert errors["error_count"] == 3
-    assert errors["missing_fields"] == ["949$h"]
-    assert errors["invalid_fields"][0]["invalid_field"] == "852$h"
-    assert errors["extra_fields"] == []
+    assert errors["error_count"] == 2
+
+
+def test_MarcValidationError_string_pattern(stub_record):
+    stub_record["960"].delete_subfield("s")
+    stub_record["960"].add_subfield("s", "1.00")
+    with pytest.raises(ValidationError) as e:
+        MonographRecord(leader=stub_record.leader, fields=stub_record.fields)
+    errors = MarcValidationError(e.value.errors()).to_dict()
+    assert errors["invalid_fields"] == [
+        {
+            "error_type": "String should match pattern. Examples: ['100', '200']",
+            "field": "960$s",
+        }
+    ]
+    assert errors["invalid_field_count"] == 1
+    assert errors["error_count"] == 1
+
+
+def test_MarcValidationError_extra_fields(stub_record):
+    record_dict = stub_record.as_dict()
+    record_dict["fields"].append(
+        {"003": {"ind1": " ", "ind2": " ", "subfields": [{"a": "foo"}]}}
+    )
+    with pytest.raises(ValidationError) as e:
+        MonographRecord(**record_dict)
+    errors = MarcValidationError(e.value.errors()).to_dict()
+    assert errors["missing_field_count"] == 0
+    assert errors["invalid_field_count"] == 1
+    assert errors["extra_field_count"] == 3
+    assert errors["error_count"] == 4
+    assert len(errors["order_item_mismatches"]) == 0
+    assert errors["missing_fields"] == []
+    assert errors["invalid_fields"] == [
+        {
+            "field": "003",
+            "error_type": "Input should be a valid string. Examples: ['OCoLC', 'DLC']",
+        }
+    ]
+    assert errors["extra_fields"] == ["003ind1", "003ind2", "003subfields"]
     assert errors["order_item_mismatches"] == []
 
 
 def test_MarcValidationError_multiple_errors_order_item(stub_record):
+    stub_record.remove_fields("980")
     stub_record["852"].delete_subfield("h")
     stub_record["852"].add_subfield("h", "ReCAP-24-119100")
     stub_record["960"].delete_subfield("t")
@@ -196,12 +277,12 @@ def test_MarcValidationError_multiple_errors_order_item(stub_record):
     with pytest.raises(ValidationError) as e:
         MonographRecord(leader=stub_record.leader, fields=stub_record.fields)
     errors = MarcValidationError(e.value.errors()).to_dict()
-    assert errors["missing_field_count"] == 0
-    assert errors["invalid_field_count"] == 1
+    assert errors["missing_field_count"] == 1
+    assert errors["invalid_field_count"] == 2
     assert errors["extra_field_count"] == 0
-    assert errors["error_count"] == 2
+    assert errors["error_count"] == 4
     assert len(errors["order_item_mismatches"]) == 1
-    assert errors["missing_fields"] == []
-    assert errors["invalid_fields"][0]["invalid_field"] == "852$h"
+    assert errors["missing_fields"] == ["980"]
+    assert errors["invalid_fields"][0]["field"] == "852$h"
     assert errors["extra_fields"] == []
     assert errors["order_item_mismatches"] == [("55", "rcmf2", "PAH")]

--- a/tests/test_marc_errors.py
+++ b/tests/test_marc_errors.py
@@ -206,8 +206,10 @@ def test_MarcValidationError_literal_error(stub_record):
             "field": "960$t",
         },
     ]
-    assert errors["invalid_field_count"] == 1
-    assert errors["error_count"] == 1
+    assert len(errors["invalid_fields"]) == 1
+    assert len(errors["missing_fields"]) == 0
+    assert len(errors["extra_fields"]) == 0
+    assert len(errors["order_item_mismatches"]) == 0
 
 
 def test_MarcValidationError_string_type(stub_record):
@@ -224,8 +226,10 @@ def test_MarcValidationError_string_type(stub_record):
         "error_type": "Input should be a valid string. Examples: ['100', '200']",
         "field": "960$s",
     }
-    assert errors["invalid_field_count"] == 2
-    assert errors["error_count"] == 2
+    assert len(errors["invalid_fields"]) == 2
+    assert len(errors["missing_fields"]) == 0
+    assert len(errors["extra_fields"]) == 0
+    assert len(errors["order_item_mismatches"]) == 0
 
 
 def test_MarcValidationError_string_pattern(stub_record):
@@ -240,8 +244,10 @@ def test_MarcValidationError_string_pattern(stub_record):
             "field": "960$s",
         }
     ]
-    assert errors["invalid_field_count"] == 1
-    assert errors["error_count"] == 1
+    assert len(errors["invalid_fields"]) == 1
+    assert len(errors["missing_fields"]) == 0
+    assert len(errors["extra_fields"]) == 0
+    assert len(errors["order_item_mismatches"]) == 0
 
 
 def test_MarcValidationError_extra_fields(stub_record):
@@ -252,10 +258,9 @@ def test_MarcValidationError_extra_fields(stub_record):
     with pytest.raises(ValidationError) as e:
         MonographRecord(**record_dict)
     errors = MarcValidationError(e.value.errors()).to_dict()
-    assert errors["missing_field_count"] == 0
-    assert errors["invalid_field_count"] == 1
-    assert errors["extra_field_count"] == 3
-    assert errors["error_count"] == 4
+    assert len(errors["missing_fields"]) == 0
+    assert len(errors["invalid_fields"]) == 1
+    assert len(errors["extra_fields"]) == 3
     assert len(errors["order_item_mismatches"]) == 0
     assert errors["missing_fields"] == []
     assert errors["invalid_fields"] == [
@@ -277,10 +282,9 @@ def test_MarcValidationError_multiple_errors_order_item(stub_record):
     with pytest.raises(ValidationError) as e:
         MonographRecord(leader=stub_record.leader, fields=stub_record.fields)
     errors = MarcValidationError(e.value.errors()).to_dict()
-    assert errors["missing_field_count"] == 1
-    assert errors["invalid_field_count"] == 2
-    assert errors["extra_field_count"] == 0
-    assert errors["error_count"] == 4
+    assert len(errors["missing_fields"]) == 1
+    assert len(errors["invalid_fields"]) == 2
+    assert len(errors["extra_fields"]) == 0
     assert len(errors["order_item_mismatches"]) == 1
     assert errors["missing_fields"] == ["980"]
     assert errors["invalid_fields"][0]["field"] == "852$h"

--- a/tests/test_marc_models.py
+++ b/tests/test_marc_models.py
@@ -2,7 +2,7 @@ import pytest
 from pydantic import ValidationError
 from contextlib import nullcontext as does_not_raise
 from pymarc import Field as MarcField
-from pymarc import Subfield
+from pymarc import Subfield, Leader, MARCReader
 from record_validator.marc_models import MonographRecord
 
 
@@ -75,8 +75,15 @@ def test_MonographRecord_valid():
 
 
 def test_MonographRecord_from_marc_valid(stub_record):
-    with does_not_raise():
-        MonographRecord(leader=stub_record.leader, fields=stub_record.fields)
+    record_1 = stub_record
+    record_2 = stub_record.as_marc21()
+    reader = MARCReader(record_2)
+    record_2 = next(reader)
+    assert isinstance(record_1.leader, str)
+    assert isinstance(record_2.leader, Leader)
+    model_1 = MonographRecord(leader=record_1.leader, fields=record_1.fields)
+    model_2 = MonographRecord(leader=record_2.leader, fields=record_2.fields)
+    assert model_1.model_dump().keys() == model_2.model_dump().keys()
 
 
 def test_MonographRecord_from_marc_dict_valid(stub_record):

--- a/tests/test_marc_models.py
+++ b/tests/test_marc_models.py
@@ -10,7 +10,7 @@ def test_MonographRecord_valid():
     model = MonographRecord(
         leader="00000cam a2200000 a 4500",
         fields=[
-            {"008": "200101s2001    xx      b    000 0 eng  "},
+            {"008": "200101s2001    xx      b    000 0 eng  d"},
             {
                 "050": {
                     "ind1": " ",

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -4,6 +4,7 @@ from pydantic import ValidationError
 from pymarc import Field as MarcField
 from pymarc import Subfield
 from record_validator.parsers import (
+    get_examples_from_schema,
     get_field_tag,
     get_missing_field_list,
     get_order_item_from_field,
@@ -15,14 +16,198 @@ from record_validator.parsers import (
 
 
 @pytest.mark.parametrize(
+    "field, examples",
+    [
+        (
+            (
+                "fields",
+                "001",
+                "value",
+            ),
+            ["ocn123456789", "ocm123456789"],
+        ),
+        (
+            (
+                "fields",
+                "003",
+                "value",
+            ),
+            ["OCoLC", "DLC"],
+        ),
+        (
+            (
+                "fields",
+                "005",
+                "value",
+            ),
+            ["20240101125000.0"],
+        ),
+        (
+            (
+                "fields",
+                "006",
+                "value",
+            ),
+            ["b|||||||||||||||||"],
+        ),
+        (
+            (
+                "fields",
+                "007",
+                "value",
+            ),
+            ["cr |||||||||||"],
+        ),
+        (
+            (
+                "fields",
+                "008",
+                "value",
+            ),
+            ["210505s2021    nyu           000 0 eng d"],
+        ),
+        (
+            (
+                "fields",
+                "245",
+            ),
+            None,
+        ),
+        (
+            (
+                "fields",
+                "901",
+                "vendor_code",
+            ),
+            None,
+        ),
+        (
+            (
+                "fields",
+                "910",
+                "library",
+            ),
+            None,
+        ),
+        (
+            (
+                "fields",
+                "852",
+                "call_no",
+            ),
+            ["ReCAP 23-000001", "ReCAP 24-100001", "ReCAP 25-222000"],
+        ),
+        (
+            (
+                "fields",
+                "050",
+                "lcc",
+            ),
+            ["PJ7962.H565", "DK504.932.R87"],
+        ),
+        (
+            (
+                "fields",
+                "980",
+                "invoice_date",
+            ),
+            ["240101", "230202"],
+        ),
+        (
+            (
+                "fields",
+                "980",
+                "invoice_price",
+            ),
+            ["100", "200"],
+        ),
+        (
+            (
+                "fields",
+                "980",
+                "invoice_shipping",
+            ),
+            ["1", "20"],
+        ),
+        (
+            (
+                "fields",
+                "980",
+                "invoice_tax",
+            ),
+            ["1", "20"],
+        ),
+        (
+            (
+                "fields",
+                "980",
+                "invoice_net_price",
+            ),
+            ["100", "200"],
+        ),
+        (
+            (
+                "fields",
+                "980",
+                "invoice_number",
+            ),
+            ["20051330", "20051331"],
+        ),
+        (
+            (
+                "fields",
+                "980",
+                "invoice_copies",
+            ),
+            ["1", "20", "4"],
+        ),
+        (
+            (
+                "fields",
+                "949",
+                "item_call_no",
+            ),
+            ["ReCAP 23-000001", "ReCAP 24-100001", "ReCAP 25-222000"],
+        ),
+        (
+            (
+                "fields",
+                "949",
+                "item_barcode",
+            ),
+            ["33433123456789", "33433111111111"],
+        ),
+        (
+            (
+                "fields",
+                "949",
+                "item_price",
+            ),
+            ["1.00", "0.00"],
+        ),
+        (
+            (
+                "fields",
+                "960",
+                "order_price",
+            ),
+            ["100", "200"],
+        ),
+    ],
+)
+def test_get_examples_from_schema(field, examples):
+    assert get_examples_from_schema(field) == examples
+
+
+@pytest.mark.parametrize(
     "tag, expected",
     [
         ("245", "data_field"),
         ("960", "960"),
         ("949", "949"),
         ("300", "data_field"),
-        ("008", "control_field"),
-        ("001", "control_field"),
+        ("008", "008"),
+        ("001", "001"),
     ],
 )
 def test_get_field_tag_from_dict(tag, expected):
@@ -37,8 +222,8 @@ def test_get_field_tag_from_dict(tag, expected):
         ("960", "960"),
         ("949", "949"),
         ("300", "data_field"),
-        ("008", "control_field"),
-        ("001", "control_field"),
+        ("008", "008"),
+        ("001", "001"),
     ],
 )
 def test_get_field_tag_from_marc(stub_record, tag, expected):


### PR DESCRIPTION
Added:
 - flake8 ignore E501 in tests directory
 - examples for each str field in `field_models.py`
 - `field_validator` on `MonographRecord` model that will convert the leader to a string if it is a `pymarc.Leader` object
 - `get_examples_from_schema` function to add examples from fields to error outputs

Changed:
 - `model_validator` on `BaseControlField` to account for extra fields passed to model
 - `ControlField` is now split into `ControlField001`, `ControlField003`, `ControlField005`, `ControlField006`, `ControlField007`, `ControlField008`,
 - parsing of `MarcError.msg` to remove `ctx` value from message and format with examples/valid values
 - `MarcValidationError.invalid_fields` is now a list of dicts containing the `error.loc_marc` value and `error.msg` (ie. `{"field": "852$h", "error_type": "String should match pattern. Examples: ["ReCAP 23-000001", "ReCAP 24-100001", "ReCAP 25-222000"]"