### PR TITLE
fixed errors in LCClass and MarcError classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,7 +127,7 @@ dmypy.json
 # localfiles/
 temp/
 *.mrk
-shelf_ready_validator/utils
+run.py
 
 # OSX
 .DS_Store

--- a/record_validator/field_models.py
+++ b/record_validator/field_models.py
@@ -1,6 +1,5 @@
 from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 from pydantic import Field, model_validator
-from pydantic_core import PydanticCustomError
 from record_validator.base_fields import BaseDataField, BaseControlField
 
 
@@ -79,23 +78,6 @@ class ControlField008(BaseControlField):
             examples=["210505s2021    nyu           000 0 eng d"],
         ),
     ]
-
-
-# class ControlField(BaseControlField):
-#     tag: Literal["001", "003", "005", "006", "007", "008"]
-#     value: Annotated[
-#         str,
-#         Field(
-#             examples=[
-#                 {"001": "ocn123456789"},
-#                 {"003": "OCoLC"},
-#                 {"005": "20210505123456"},
-#                 {"006": "m d"},
-#                 {"007": "cr"},
-#                 {"008": "210505s2021    nyu           000 0 eng d"},
-#             ]
-#         ),
-#     ]
 
 
 class InvoiceField(BaseDataField):
@@ -235,8 +217,8 @@ class LCClass(BaseDataField):
     def validate_indicator_pair(self) -> "LCClass":
         valid_combos = [(" ", "4"), ("", "4"), ("0", "0"), ("1", "0")]
         if (self.ind1, self.ind2) not in valid_combos:
-            raise PydanticCustomError(
-                "literal_error", f"Invalid indicators: [{self.ind1}, {self.ind2}]"
+            raise ValueError(
+                f"Invalid indicators. Valid combinations are: {valid_combos}"
             )
         else:
             return self

--- a/tests/test_field_models.py
+++ b/tests/test_field_models.py
@@ -1240,7 +1240,7 @@ def test_LCClass_invalid_indicators(ind1_value, ind2_value):
 def test_LCClass_invalid_indicator_combo(ind1_value, ind2_value):
     with pytest.raises(ValidationError) as e:
         LCClass(tag="050", ind1=ind1_value, ind2=ind2_value, subfields=[{"a": "F00"}])
-    assert e.value.errors()[0]["type"] == "literal_error"
+    assert e.value.errors()[0]["type"] == "value_error"
     assert len(e.value.errors()) == 1
 
 


### PR DESCRIPTION
 - `PydanticCustomError` in `LCClass` class is now a `ValueError`
 - added input to invalid_fields dict in `MarcError` class