### PR TITLE
fixed error with extra fields, added tests

### DIFF
--- a/record_validator/marc_errors.py
+++ b/record_validator/marc_errors.py
@@ -63,11 +63,10 @@ class MarcError:
                 "item_type",
             )
         if (
-            self.type == "missing"
-            and self.original_error["msg"] == f"Field required: {self.input}"
+            self.type == "missing" and "Field required:" in self.original_error["msg"]
         ) or (
             self.type == "extra_forbidden"
-            and self.original_error["msg"] == f"Extra field:  {self.input}"
+            and "Extra field:" in self.original_error["msg"]
         ):
             return tuple([i for i in self.original_error["loc"]] + [self.input])
         else:
@@ -96,7 +95,7 @@ class MarcError:
         if self.type == "order_item_mismatch":
             return ("960$t", "949_$l", "949_$t")
         if self.type == "extra_forbidden":
-            locs = [i for i in self.loc if isinstance(i, str)]
+            locs = [str(i) for i in self.loc]
         else:
             locs = [i for i in self.loc if i != "subfields" and isinstance(i, str)]
         for i in locs:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,85 +4,11 @@ from pymarc import Field as MarcField
 
 
 @pytest.fixture
-def stub_item():
-    item_field = MarcField(
-        tag="949",
-        indicators=[" ", "1"],
-        subfields=[
-            Subfield(code="z", value="8528"),
-            Subfield(code="a", value="ReCAP 23-100000"),
-            Subfield(code="c", value="1"),
-            Subfield(code="h", value="43"),
-            Subfield(code="i", value="33433123456789"),
-            Subfield(code="l", value="rcmf2"),
-            Subfield(code="m", value="bar"),
-            Subfield(code="p", value="1.00"),
-            Subfield(code="t", value="55"),
-            Subfield(code="u", value="foo"),
-            Subfield(code="v", value="AUXAM"),
-        ],
-    )
-    return item_field
-
-
-@pytest.fixture
-def stub_item_dict():
-    return {
-        "949": [
-            {"z": "8528"},
-            {"a": "ReCAP 23-100000"},
-            {"c": "1"},
-            {"h": "43"},
-            {"i": "33433123456789"},
-            {"l": "rcmf2"},
-            {"m": "bar"},
-            {"p": "1.00"},
-            {"t": "55"},
-            {"u": "foo"},
-            {"v": "AUXAM"},
-        ]
-    }
-
-
-@pytest.fixture
-def stub_order():
-    order_field = MarcField(
-        tag="960",
-        indicators=[" ", " "],
-        subfields=[
-            Subfield(code="s", value="100"),
-            Subfield(code="t", value="MAF"),
-            Subfield(code="u", value="123456apprv"),
-        ],
-    )
-    return order_field
-
-
-@pytest.fixture
-def stub_invoice():
-    invoice_field = MarcField(
-        tag="980",
-        indicators=[" ", " "],
-        subfields=[
-            Subfield(code="a", value="240101"),
-            Subfield(code="b", value="100"),
-            Subfield(code="c", value="100"),
-            Subfield(code="d", value="000"),
-            Subfield(code="e", value="200"),
-            Subfield(code="f", value="123456"),
-            Subfield(code="g", value="1"),
-        ],
-    )
-
-    return invoice_field
-
-
-@pytest.fixture
-def stub_record(stub_item, stub_order, stub_invoice):
+def stub_record():
     bib = Record()
     bib.leader = "00454cam a22001575i 4500"
-    bib.add_field(MarcField(tag="008", data="190306s2017    ht a   j      000 1 hat d"))
     bib.add_field(MarcField(tag="001", data="on1381158740"))
+    bib.add_field(MarcField(tag="008", data="190306s2017    ht a   j      000 1 hat d"))
     bib.add_field(
         MarcField(
             tag="050",
@@ -145,31 +71,57 @@ def stub_record(stub_item, stub_order, stub_invoice):
             ],
         )
     )
-    bib.add_field(stub_item)
-    bib.add_field(stub_order)
-    bib.add_field(stub_invoice)
+    bib.add_field(
+        MarcField(
+            tag="949",
+            indicators=[" ", "1"],
+            subfields=[
+                Subfield(code="z", value="8528"),
+                Subfield(code="a", value="ReCAP 23-100000"),
+                Subfield(code="c", value="1"),
+                Subfield(code="h", value="43"),
+                Subfield(code="i", value="33433123456789"),
+                Subfield(code="l", value="rcmf2"),
+                Subfield(code="m", value="bar"),
+                Subfield(code="p", value="1.00"),
+                Subfield(code="t", value="55"),
+                Subfield(code="u", value="foo"),
+                Subfield(code="v", value="AUXAM"),
+            ],
+        )
+    )
+    bib.add_field(
+        MarcField(
+            tag="960",
+            indicators=[" ", " "],
+            subfields=[
+                Subfield(code="s", value="100"),
+                Subfield(code="t", value="MAF"),
+                Subfield(code="u", value="123456apprv"),
+            ],
+        )
+    )
+    bib.add_field(
+        MarcField(
+            tag="980",
+            indicators=[" ", " "],
+            subfields=[
+                Subfield(code="a", value="240101"),
+                Subfield(code="b", value="100"),
+                Subfield(code="c", value="100"),
+                Subfield(code="d", value="000"),
+                Subfield(code="e", value="200"),
+                Subfield(code="f", value="123456"),
+                Subfield(code="g", value="1"),
+            ],
+        )
+    )
     return bib
 
 
 @pytest.fixture
-def stub_record_with_dupes(stub_record):
+def stub_record_multiple_items(stub_record):
     dupe_record = stub_record
-    dupe_record.add_field(
-        MarcField(tag="050", indicators=[" ", "4"], subfields=[Subfield("h", "foo")])
-    )
-    dupe_record.add_field(
-        MarcField(
-            tag="852",
-            indicators=["8", " "],
-            subfields=[Subfield("h", "ReCAP 25-000000")],
-        )
-    )
-    dupe_record.add_field(
-        MarcField(tag="901", indicators=[" ", " "], subfields=[Subfield("a", "foo")])
-    )
-    dupe_record.add_field(
-        MarcField(tag="910", indicators=[" ", " "], subfields=[Subfield("a", "foo")])
-    )
     dupe_record.add_field(
         MarcField(
             tag="949",
@@ -180,7 +132,7 @@ def stub_record_with_dupes(stub_record):
                 Subfield(code="c", value="1"),
                 Subfield(code="h", value="43"),
                 Subfield(code="i", value="33433123456789"),
-                Subfield(code="l", value="rc2ma"),
+                Subfield(code="l", value="rcmf2"),
                 Subfield(code="m", value="bar"),
                 Subfield(code="p", value="1.00"),
                 Subfield(code="t", value="55"),
@@ -189,7 +141,47 @@ def stub_record_with_dupes(stub_record):
             ],
         )
     )
-    dupe_record.add_field(
-        MarcField(tag="980", indicators=[" ", " "], subfields=[Subfield("a", "foo")])
-    )
     return dupe_record
+
+
+@pytest.fixture
+def stub_dance_record(stub_record):
+    stub_record.remove_fields("949", "852")
+    stub_record.remove_fields("960")
+    stub_record.add_field(
+        MarcField(
+            tag="960",
+            indicators=[" ", "1"],
+            subfields=[Subfield(code="t", value="PAD")],
+        )
+    )
+    return stub_record
+
+
+@pytest.fixture
+def stub_pamphlet_record(stub_record):
+    stub_record.remove_fields("949", "852")
+    stub_record["300"].delete_subfield("a")
+    stub_record["300"].add_subfield("a", "5 pages")
+    return stub_record
+
+
+@pytest.fixture
+def stub_catalogue_record(stub_record):
+    stub_record.remove_fields("949", "852")
+    stub_record.add_field(
+        MarcField(
+            tag="650",
+            indicators=[" ", " "],
+            subfields=[Subfield(code="v", value="Catalogues raisonnés")],
+        )
+    )
+    return stub_record
+
+
+@pytest.fixture
+def stub_multivol_record(stub_record):
+    stub_record.remove_fields("949", "852")
+    stub_record["300"].delete_subfield("a")
+    stub_record["300"].add_subfield("a", "5 volumes")
+    return stub_record

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,5 +1,3 @@
-from pymarc import Field as MarcField
-from pymarc import Subfield
 import pytest
 from record_validator.adapters import (
     MonographRecordAdapter,
@@ -17,39 +15,20 @@ def test_get_material_type_monograph(stub_record):
     assert get_material_type(stub_record.fields) == "monograph"
 
 
-def test_get_material_type_dance(stub_record):
-    stub_record.remove_fields("960")
-    stub_record.add_field(
-        MarcField(
-            tag="960",
-            indicators=[" ", "1"],
-            subfields=[Subfield(code="t", value="PAD")],
-        )
-    )
-    assert get_material_type(stub_record.fields) == "other"
+def test_get_material_type_dance(stub_dance_record):
+    assert get_material_type(stub_dance_record.fields) == "other"
 
 
-def test_get_material_type_pamphlet(stub_record):
-    stub_record["300"].delete_subfield("a")
-    stub_record["300"].add_subfield("a", "5 pages")
-    assert get_material_type(stub_record.fields) == "other"
+def test_get_material_type_pamphlet(stub_pamphlet_record):
+    assert get_material_type(stub_pamphlet_record.fields) == "other"
 
 
-def test_get_material_type_catalogue(stub_record):
-    stub_record.add_field(
-        MarcField(
-            tag="650",
-            indicators=[" ", " "],
-            subfields=[Subfield(code="v", value="Catalogues raisonnés")],
-        )
-    )
-    assert get_material_type(stub_record.fields) == "other"
+def test_get_material_type_catalogue(stub_catalogue_record):
+    assert get_material_type(stub_catalogue_record.fields) == "other"
 
 
-def test_get_material_type_multivol(stub_record):
-    stub_record["300"].delete_subfield("a")
-    stub_record["300"].add_subfield("a", "5 volumes")
-    assert get_material_type(stub_record.fields) == "other"
+def test_get_material_type_multivol(stub_multivol_record):
+    assert get_material_type(stub_multivol_record.fields) == "other"
 
 
 def test_get_material_type_dict(stub_record):

--- a/tests/test_base_fields.py
+++ b/tests/test_base_fields.py
@@ -21,8 +21,8 @@ def test_get_control_field_input_dict(stub_record):
     stub_record_dict = stub_record.as_dict()
     field = stub_record_dict["fields"][0]
     parsed_field = get_control_field_input(field)
-    assert parsed_field["tag"] == "008"
-    assert parsed_field["value"] == "190306s2017    ht a   j      000 1 hat d"
+    assert parsed_field["tag"] == "001"
+    assert parsed_field["value"] == "on1381158740"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_field_models.py
+++ b/tests/test_field_models.py
@@ -58,29 +58,15 @@ def test_BibCallNo_valid(ind1_value, ind2_value, field_value):
     }
 
 
-def test_BibCallNo_valid_from_field(stub_record_with_dupes):
-    field_1 = stub_record_with_dupes.get_fields("852")[0]
-    field_2 = stub_record_with_dupes.get_fields("852")[1]
-    assert isinstance(field_1, MarcField)
-    assert isinstance(field_2, MarcField)
-    model_1 = BibCallNo.model_validate(field_1, from_attributes=True)
-    model_2 = BibCallNo.model_validate(field_2, from_attributes=True)
-    assert model_1.model_dump(by_alias=True) == {
+def test_BibCallNo_valid_from_field(stub_record):
+    field = stub_record.get_fields("852")[0]
+    assert isinstance(field, MarcField)
+    model = BibCallNo.model_validate(field, from_attributes=True)
+    assert model.model_dump(by_alias=True) == {
         "852": {
             "ind1": "8",
             "ind2": " ",
             "subfields": [{"h": "ReCAP 23-100000"}],
-        }
-    }
-    assert model_2.model_dump(by_alias=True) == {
-        "852": {
-            "ind1": "8",
-            "ind2": " ",
-            "subfields": [
-                {
-                    "h": "ReCAP 25-000000",
-                }
-            ],
         }
     }
 

--- a/tests/test_marc_errors.py
+++ b/tests/test_marc_errors.py
@@ -220,345 +220,621 @@ def test_get_examples_from_schema(field, examples):
     assert get_examples_from_schema(field) == examples
 
 
-def test_MarcError_string_pattern(stub_record):
-    stub_record.remove_fields("852")
-    stub_record.add_field(
-        MarcField(
-            tag="852",
-            indicators=["8", " "],
-            subfields=[Subfield(code="h", value="ReCAP-24-119100")],
+class TestMarcErrorMonograph:
+    def test_MarcError_string_pattern(self, stub_record):
+        stub_record.remove_fields("852")
+        stub_record.add_field(
+            MarcField(
+                tag="852",
+                indicators=["8", " "],
+                subfields=[Subfield(code="h", value="ReCAP-24-119100")],
+            )
         )
-    )
-    with pytest.raises(ValidationError) as e:
-        RecordModel(leader=stub_record.leader, fields=stub_record.fields)
-    error = MarcError(e.value.errors()[0])
-    assert len(e.value.errors()) == 1
-    assert error.loc == ("fields", "monograph", "852", "call_no")
-    assert error.input == "ReCAP-24-119100"
-    assert isinstance(error.ctx, dict)
-    assert error.type == "string_pattern_mismatch"
-    assert (
-        error.msg
-        == "String should match pattern. Examples: ['ReCAP 23-000001', 'ReCAP 24-100001', 'ReCAP 25-222000']"
-    )
-    assert error.loc_marc == "852$h"
-
-
-def test_MarcError_missing_field(stub_record):
-    stub_record["960"].delete_subfield("t")
-    with pytest.raises(ValidationError) as e:
-        RecordModel(leader=stub_record.leader, fields=stub_record.fields)
-    error = MarcError(e.value.errors()[0])
-    assert len(e.value.errors()) == 1
-    assert error.loc == (
-        "fields",
-        "monograph",
-        "960",
-        "order_location",
-    )
-    assert error.type == "missing"
-    assert error.input == {
-        "ind1": " ",
-        "ind2": " ",
-        "subfields": [{"s": "100"}, {"u": "123456apprv"}],
-        "tag": "960",
-        "order_fund": "123456apprv",
-        "order_price": "100",
-    }
-    assert error.ctx is None
-    assert error.msg == "Field required"
-    assert error.loc_marc == "960$t"
-
-
-def test_MarcError_missing_entire_field(stub_record):
-    stub_record.remove_fields("980")
-    with pytest.raises(ValidationError) as e:
-        RecordModel(leader=stub_record.leader, fields=stub_record.fields)
-    error = MarcError(e.value.errors()[0])
-    assert len(e.value.errors()) == 1
-    assert error.loc == (
-        "fields",
-        "monograph",
-        "980",
-    )
-    assert error.ctx is None
-    assert error.type == "missing"
-    assert error.msg == "Field required: 980"
-    assert error.loc_marc == "980"
-
-
-def test_MarcError_missing_subfield(stub_record):
-    stub_record["960"].delete_subfield("t")
-    with pytest.raises(ValidationError) as e:
-        RecordModel(leader=stub_record.leader, fields=stub_record.fields)
-    error = MarcError(e.value.errors()[0])
-    assert len(e.value.errors()) == 1
-    assert error.loc == ("fields", "monograph", "960", "order_location")
-    assert error.type == "missing"
-    assert error.input == {
-        "ind1": " ",
-        "ind2": " ",
-        "subfields": [{"s": "100"}, {"u": "123456apprv"}],
-        "order_fund": "123456apprv",
-        "order_price": "100",
-        "tag": "960",
-    }
-    assert error.ctx is None
-    assert error.msg == "Field required"
-    assert error.loc_marc == "960$t"
-
-
-def test_MarcError_literal(stub_record):
-    stub_record["960"].delete_subfield("t")
-    stub_record["960"].add_subfield("t", "foo")
-    with pytest.raises(ValidationError) as e:
-        RecordModel(leader=stub_record.leader, fields=stub_record.fields)
-    error = MarcError(e.value.errors()[0])
-    assert len(e.value.errors()) == 1
-    assert error.loc == ("fields", "monograph", "960", "order_location")
-    assert error.input == "foo"
-    assert isinstance(error.ctx, dict)
-    assert error.type == "literal_error"
-    assert (
-        error.msg
-        == "Input should be: 'MAB', 'MAF', 'MAG', 'MAL', 'MAP', 'MAS', 'PAD', 'PAH', 'PAM', 'PAT' or 'SC'"
-    )
-    assert error.loc_marc == "960$t"
-
-
-def test_MarcError_literal_indicator_error(stub_record):
-    stub_record.remove_fields("960")
-    stub_record.add_field(
-        MarcField(
-            tag="960",
-            indicators=["7", " "],
-            subfields=[
-                Subfield(code="s", value="100"),
-                Subfield(code="t", value="MAF"),
-                Subfield(code="u", value="123456apprv"),
-            ],
+        with pytest.raises(ValidationError) as e:
+            RecordModel(leader=stub_record.leader, fields=stub_record.fields)
+        error = MarcError(e.value.errors()[0])
+        assert len(e.value.errors()) == 1
+        assert error.loc == ("fields", "monograph", "852", "call_no")
+        assert error.input == "ReCAP-24-119100"
+        assert isinstance(error.ctx, dict)
+        assert error.type == "string_pattern_mismatch"
+        assert (
+            error.msg
+            == "String should match pattern. Examples: ['ReCAP 23-000001', 'ReCAP 24-100001', 'ReCAP 25-222000']"
         )
-    )
-    with pytest.raises(ValidationError) as e:
-        RecordModel(leader=stub_record.leader, fields=stub_record.fields)
-    error = MarcError(e.value.errors()[0])
-    assert len(e.value.errors()) == 1
-    assert error.loc == ("fields", "monograph", "960", "ind1")
-    assert error.input == "7"
-    assert isinstance(error.ctx, dict)
-    assert error.type == "literal_error"
-    assert error.msg == "Input should be: ' ' or ''"
-    assert error.loc_marc == "960ind1"
+        assert error.loc_marc == "852$h"
 
-
-def test_MarcError_lcc_indicator_error(stub_record):
-    stub_record.remove_fields("050")
-    stub_record.add_field(
-        MarcField(
-            tag="050",
-            indicators=[" ", "0"],
-            subfields=[
-                Subfield(code="a", value="F00"),
-            ],
+    def test_MarcError_missing_entire_field(self, stub_record):
+        stub_record.remove_fields("980")
+        with pytest.raises(ValidationError) as e:
+            RecordModel(leader=stub_record.leader, fields=stub_record.fields)
+        error = MarcError(e.value.errors()[0])
+        assert len(e.value.errors()) == 1
+        assert error.loc == (
+            "fields",
+            "monograph",
+            "980",
         )
-    )
-    with pytest.raises(ValidationError) as e:
-        RecordModel(leader=stub_record.leader, fields=stub_record.fields)
-    error = MarcError(e.value.errors()[0])
-    assert len(e.value.errors()) == 1
-    assert error.loc == (
-        "fields",
-        "monograph",
-        "050",
-    )
-    assert error.input == [" ", "0"]
-    assert isinstance(error.ctx, dict)
-    assert error.type == "value_error"
-    assert (
-        error.msg
-        == "Invalid indicators. Valid combinations are: [(' ', '4'), ('', '4'), ('0', '0'), ('1', '0')]"
-    )
-    assert error.loc_marc == "050"
+        assert error.ctx is None
+        assert error.type == "missing"
+        assert error.msg == "Field required: 980"
+        assert error.loc_marc == "980"
 
+    def test_MarcError_missing_subfield(self, stub_record):
+        stub_record["960"].delete_subfield("t")
+        with pytest.raises(ValidationError) as e:
+            RecordModel(leader=stub_record.leader, fields=stub_record.fields)
+        error = MarcError(e.value.errors()[0])
+        assert len(e.value.errors()) == 1
+        assert error.loc == ("fields", "monograph", "960", "order_location")
+        assert error.type == "missing"
+        assert error.input == {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [{"s": "100"}, {"u": "123456apprv"}],
+            "order_fund": "123456apprv",
+            "order_price": "100",
+            "tag": "960",
+        }
+        assert error.ctx is None
+        assert error.msg == "Field required"
+        assert error.loc_marc == "960$t"
 
-def test_MarcError_extra_fields(stub_record):
-    record_dict = stub_record.as_dict()
-    record_dict["fields"].append(
-        {"003": {"ind1": " ", "ind2": " ", "subfields": [{"a": "foo"}]}}
-    )
-    with pytest.raises(ValidationError) as e:
-        RecordModel(**record_dict)
-    extra_field_errors = [i for i in e.value.errors() if i["type"] == "extra_forbidden"]
-    string_type_error = [i for i in e.value.errors() if i["type"] == "string_type"]
-    error = MarcError(extra_field_errors[0])
-    assert len(e.value.errors()) == 4
-    assert len(extra_field_errors) == 3
-    assert len(string_type_error) == 1
-    assert error.loc == (
-        "fields",
-        "monograph",
-        "003",
-        "ind1",
-    )
-    assert error.input == " "
-    assert error.ctx is None
-    assert error.type == "extra_forbidden"
-    assert error.msg == "Extra inputs are not permitted"
-    assert error.loc_marc == "003ind1"
+    def test_MarcError_literal(self, stub_record):
+        stub_record["960"].delete_subfield("t")
+        stub_record["960"].add_subfield("t", "foo")
+        with pytest.raises(ValidationError) as e:
+            RecordModel(leader=stub_record.leader, fields=stub_record.fields)
+        error = MarcError(e.value.errors()[0])
+        assert len(e.value.errors()) == 1
+        assert error.loc == ("fields", "monograph", "960", "order_location")
+        assert error.input == "foo"
+        assert isinstance(error.ctx, dict)
+        assert error.type == "literal_error"
+        assert (
+            error.msg
+            == "Input should be: 'MAB', 'MAF', 'MAG', 'MAL', 'MAP', 'MAS', 'PAD', 'PAH', 'PAM', 'PAT' or 'SC'"
+        )
+        assert error.loc_marc == "960$t"
 
+    def test_MarcError_literal_indicator_error(self, stub_record):
+        stub_record.remove_fields("960")
+        stub_record.add_field(
+            MarcField(
+                tag="960",
+                indicators=["7", " "],
+                subfields=[
+                    Subfield(code="s", value="100"),
+                    Subfield(code="t", value="MAF"),
+                    Subfield(code="u", value="123456apprv"),
+                ],
+            )
+        )
+        with pytest.raises(ValidationError) as e:
+            RecordModel(leader=stub_record.leader, fields=stub_record.fields)
+        error = MarcError(e.value.errors()[0])
+        assert len(e.value.errors()) == 1
+        assert error.loc == ("fields", "monograph", "960", "ind1")
+        assert error.input == "7"
+        assert isinstance(error.ctx, dict)
+        assert error.type == "literal_error"
+        assert error.msg == "Input should be: ' ' or ''"
+        assert error.loc_marc == "960ind1"
 
-def test_MarcError_order_item_mismatch(stub_record):
-    stub_record["960"].delete_subfield("t")
-    stub_record["960"].add_subfield("t", "MAB")
-    with pytest.raises(ValidationError) as e:
-        RecordModel(leader=stub_record.leader, fields=stub_record.fields)
-    error = MarcError(e.value.errors()[0])
-    assert len(e.value.errors()) == 1
-    assert error.loc == (
-        "order_field",
-        "item_location",
-        "item_type",
-    )
-    assert sorted(error.input) == sorted(("MAB", "rcmf2", "55"))
-    assert error.ctx is None
-    assert error.type == "order_item_mismatch"
-    assert (
-        error.msg
-        == "Invalid combination of item_type, order_location and item_location: {'order_location': 'MAB', 'item_location': 'rcmf2', 'item_type': '55'}"
-    )
-    assert error.loc_marc == ("960$t", "949_$l", "949_$t")
+    def test_MarcError_lcc_indicator_error(self, stub_record):
+        stub_record.remove_fields("050")
+        stub_record.add_field(
+            MarcField(
+                tag="050",
+                indicators=[" ", "0"],
+                subfields=[
+                    Subfield(code="a", value="F00"),
+                ],
+            )
+        )
+        with pytest.raises(ValidationError) as e:
+            RecordModel(leader=stub_record.leader, fields=stub_record.fields)
+        error = MarcError(e.value.errors()[0])
+        assert len(e.value.errors()) == 1
+        assert error.loc == (
+            "fields",
+            "monograph",
+            "050",
+        )
+        assert error.input == [" ", "0"]
+        assert isinstance(error.ctx, dict)
+        assert error.type == "value_error"
+        assert (
+            error.msg
+            == "Invalid indicators. Valid combinations are: [(' ', '4'), ('', '4'), ('0', '0'), ('1', '0')]"
+        )
+        assert error.loc_marc == "050"
 
-
-def test_MarcError_string_type(stub_record):
-    stub_record["960"].delete_subfield("s")
-    stub_record["960"].add_subfield("s", 1.00)
-    with pytest.raises(ValidationError) as e:
-        RecordModel(leader=stub_record.leader, fields=stub_record.fields)
-    errors = [MarcError(i) for i in e.value.errors()]
-    error_locs = [i.loc for i in errors]
-    error_types = [i.type for i in errors]
-    errors_loc_marc = [i.loc_marc for i in errors]
-    assert len(errors) == 2
-    assert sorted(error_locs) == sorted(
-        [
-            ("fields", "monograph", "960", "subfields", 0, "s"),
-            ("fields", "monograph", "960", "order_price"),
+    def test_MarcError_extra_fields(self, stub_record):
+        record_dict = stub_record.as_dict()
+        record_dict["fields"].append(
+            {"003": {"ind1": " ", "ind2": " ", "subfields": [{"a": "foo"}]}}
+        )
+        with pytest.raises(ValidationError) as e:
+            RecordModel(**record_dict)
+        extra_field_errors = [
+            i for i in e.value.errors() if i["type"] == "extra_forbidden"
         ]
-    )
-    assert all(isinstance(i.input, float) for i in errors)
-    assert error_types == ["string_type", "string_type"]
-    assert errors_loc_marc == ["960$s", "960$s"]
+        string_type_error = [i for i in e.value.errors() if i["type"] == "string_type"]
+        error = MarcError(extra_field_errors[0])
+        assert len(e.value.errors()) == 4
+        assert len(extra_field_errors) == 3
+        assert len(string_type_error) == 1
+        assert error.loc == (
+            "fields",
+            "monograph",
+            "003",
+            "ind1",
+        )
+        assert error.input == " "
+        assert error.ctx is None
+        assert error.type == "extra_forbidden"
+        assert error.msg == "Extra inputs are not permitted"
+        assert error.loc_marc == "003ind1"
+
+    def test_MarcError_order_item_mismatch(self, stub_record):
+        stub_record["960"].delete_subfield("t")
+        stub_record["960"].add_subfield("t", "MAB")
+        with pytest.raises(ValidationError) as e:
+            RecordModel(leader=stub_record.leader, fields=stub_record.fields)
+        error = MarcError(e.value.errors()[0])
+        assert len(e.value.errors()) == 1
+        assert error.loc == (
+            "order_field",
+            "item_location",
+            "item_type",
+        )
+        assert sorted(error.input) == sorted(("MAB", "rcmf2", "55"))
+        assert error.ctx is None
+        assert error.type == "order_item_mismatch"
+        assert (
+            error.msg
+            == "Invalid combination of item_type, order_location and item_location: {'order_location': 'MAB', 'item_location': 'rcmf2', 'item_type': '55'}"
+        )
+        assert error.loc_marc == ("960$t", "949_$l", "949_$t")
+
+    def test_MarcError_string_type(self, stub_record):
+        stub_record["960"].delete_subfield("s")
+        stub_record["960"].add_subfield("s", 1.00)
+        with pytest.raises(ValidationError) as e:
+            RecordModel(leader=stub_record.leader, fields=stub_record.fields)
+        errors = [MarcError(i) for i in e.value.errors()]
+        error_locs = [i.loc for i in errors]
+        error_types = [i.type for i in errors]
+        errors_loc_marc = [i.loc_marc for i in errors]
+        assert len(errors) == 2
+        assert sorted(error_locs) == sorted(
+            [
+                ("fields", "monograph", "960", "subfields", 0, "s"),
+                ("fields", "monograph", "960", "order_price"),
+            ]
+        )
+        assert all(isinstance(i.input, float) for i in errors)
+        assert error_types == ["string_type", "string_type"]
+        assert errors_loc_marc == ["960$s", "960$s"]
 
 
-def test_MarcValidationError_literal_error(stub_record):
-    stub_record["960"].delete_subfield("t")
-    stub_record["960"].add_subfield("t", "foo")
-    with pytest.raises(ValidationError) as e:
-        RecordModel(leader=stub_record.leader, fields=stub_record.fields)
-    errors = MarcValidationError(e.value.errors()).to_dict()
-    assert errors["error_count"] == 1
-    assert errors["invalid_fields"] == [
-        {
-            "error_type": "Input should be: 'MAB', 'MAF', 'MAG', 'MAL', 'MAP', 'MAS', 'PAD', 'PAH', 'PAM', 'PAT' or 'SC'",
-            "field": "960$t",
-            "input": "foo",
-        },
-    ]
-    assert len(errors["invalid_fields"]) == 1
-    assert len(errors["missing_fields"]) == 0
-    assert len(errors["extra_fields"]) == 0
-    assert len(errors["order_item_mismatches"]) == 0
+class TestMarcErrorOther:
+    def test_MarcError_string_pattern(self, stub_pamphlet_record):
+        stub_pamphlet_record["960"].delete_subfield("s")
+        stub_pamphlet_record["960"].add_subfield("s", "1.00")
+        with pytest.raises(ValidationError) as e:
+            RecordModel(
+                leader=stub_pamphlet_record.leader, fields=stub_pamphlet_record.fields
+            )
+        error = MarcError(e.value.errors()[0])
+        assert len(e.value.errors()) == 1
+        assert error.loc == ("fields", "other", "960", "order_price")
+        assert error.input == "1.00"
+        assert isinstance(error.ctx, dict)
+        assert error.type == "string_pattern_mismatch"
+        assert error.msg == "String should match pattern. Examples: ['100', '200']"
+        assert error.loc_marc == "960$s"
+
+    def test_MarcError_missing_entire_field(self, stub_pamphlet_record):
+        stub_pamphlet_record.remove_fields("980")
+        with pytest.raises(ValidationError) as e:
+            RecordModel(
+                leader=stub_pamphlet_record.leader, fields=stub_pamphlet_record.fields
+            )
+        error = MarcError(e.value.errors()[0])
+        assert len(e.value.errors()) == 1
+        assert error.loc == (
+            "fields",
+            "other",
+            "980",
+        )
+        assert error.ctx is None
+        assert error.type == "missing"
+        assert error.msg == "Field required: 980"
+        assert error.loc_marc == "980"
+
+    def test_MarcError_missing_subfield(self, stub_pamphlet_record):
+        stub_pamphlet_record["960"].delete_subfield("t")
+        with pytest.raises(ValidationError) as e:
+            RecordModel(
+                leader=stub_pamphlet_record.leader, fields=stub_pamphlet_record.fields
+            )
+        error = MarcError(e.value.errors()[0])
+        assert len(e.value.errors()) == 1
+        assert error.loc == ("fields", "other", "960", "order_location")
+        assert error.type == "missing"
+        assert error.input == {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [{"s": "100"}, {"u": "123456apprv"}],
+            "order_fund": "123456apprv",
+            "order_price": "100",
+            "tag": "960",
+        }
+        assert error.ctx is None
+        assert error.msg == "Field required"
+        assert error.loc_marc == "960$t"
+
+    def test_MarcError_literal(self, stub_pamphlet_record):
+        stub_pamphlet_record["960"].delete_subfield("t")
+        stub_pamphlet_record["960"].add_subfield("t", "foo")
+        with pytest.raises(ValidationError) as e:
+            RecordModel(
+                leader=stub_pamphlet_record.leader, fields=stub_pamphlet_record.fields
+            )
+        error = MarcError(e.value.errors()[0])
+        assert len(e.value.errors()) == 1
+        assert error.loc == ("fields", "other", "960", "order_location")
+        assert error.input == "foo"
+        assert isinstance(error.ctx, dict)
+        assert error.type == "literal_error"
+        assert (
+            error.msg
+            == "Input should be: 'MAB', 'MAF', 'MAG', 'MAL', 'MAP', 'MAS', 'PAD', 'PAH', 'PAM', 'PAT' or 'SC'"
+        )
+        assert error.loc_marc == "960$t"
+
+    def test_MarcError_literal_indicator_error(self, stub_pamphlet_record):
+        stub_pamphlet_record.remove_fields("960")
+        stub_pamphlet_record.add_field(
+            MarcField(
+                tag="960",
+                indicators=["7", " "],
+                subfields=[
+                    Subfield(code="s", value="100"),
+                    Subfield(code="t", value="MAF"),
+                    Subfield(code="u", value="123456apprv"),
+                ],
+            )
+        )
+        with pytest.raises(ValidationError) as e:
+            RecordModel(
+                leader=stub_pamphlet_record.leader, fields=stub_pamphlet_record.fields
+            )
+        error = MarcError(e.value.errors()[0])
+        assert len(e.value.errors()) == 1
+        assert error.loc == ("fields", "other", "960", "ind1")
+        assert error.input == "7"
+        assert isinstance(error.ctx, dict)
+        assert error.type == "literal_error"
+        assert error.msg == "Input should be: ' ' or ''"
+        assert error.loc_marc == "960ind1"
+
+    def test_MarcError_lcc_indicator_error(self, stub_pamphlet_record):
+        stub_pamphlet_record.remove_fields("050")
+        stub_pamphlet_record.add_field(
+            MarcField(
+                tag="050",
+                indicators=[" ", "0"],
+                subfields=[
+                    Subfield(code="a", value="F00"),
+                ],
+            )
+        )
+        with pytest.raises(ValidationError) as e:
+            RecordModel(
+                leader=stub_pamphlet_record.leader, fields=stub_pamphlet_record.fields
+            )
+        error = MarcError(e.value.errors()[0])
+        assert len(e.value.errors()) == 1
+        assert error.loc == (
+            "fields",
+            "other",
+            "050",
+        )
+        assert error.input == [" ", "0"]
+        assert isinstance(error.ctx, dict)
+        assert error.type == "value_error"
+        assert (
+            error.msg
+            == "Invalid indicators. Valid combinations are: [(' ', '4'), ('', '4'), ('0', '0'), ('1', '0')]"
+        )
+        assert error.loc_marc == "050"
+
+    def test_MarcError_extra_fields(self, stub_record):
+        stub_record.remove_fields("300")
+        stub_record.add_field(
+            MarcField(
+                tag="300",
+                indicators=[" ", " "],
+                subfields=[
+                    Subfield(code="a", value="5 pages :"),
+                ],
+            )
+        )
+        record_dict = stub_record.as_dict()
+        with pytest.raises(ValidationError) as e:
+            RecordModel(**record_dict)
+        error_1 = MarcError(e.value.errors()[0])
+        error_2 = MarcError(e.value.errors()[1])
+        assert len(e.value.errors()) == 2
+        assert error_1.type == "extra_forbidden"
+        assert error_1.loc == ("fields", "other", "852")
+        assert error_1.input == "852"
+        assert error_1.ctx is None
+        assert error_1.msg == "Extra field: 852"
+        assert error_1.loc_marc == "852"
+        assert error_2.type == "extra_forbidden"
+        assert error_2.loc == ("fields", "other", "949")
+        assert error_2.input == "949"
+        assert error_2.ctx is None
+        assert error_2.msg == "Extra field: 949"
+        assert error_2.loc_marc == "949"
+
+    def test_MarcError_string_type(self, stub_pamphlet_record):
+        stub_pamphlet_record["960"].delete_subfield("s")
+        stub_pamphlet_record["960"].add_subfield("s", 1.00)
+        with pytest.raises(ValidationError) as e:
+            RecordModel(
+                leader=stub_pamphlet_record.leader, fields=stub_pamphlet_record.fields
+            )
+        errors = [MarcError(i) for i in e.value.errors()]
+        error_locs = [i.loc for i in errors]
+        error_types = [i.type for i in errors]
+        errors_loc_marc = [i.loc_marc for i in errors]
+        assert len(errors) == 2
+        assert sorted(error_locs) == sorted(
+            [
+                ("fields", "other", "960", "subfields", 0, "s"),
+                ("fields", "other", "960", "order_price"),
+            ]
+        )
+        assert all(isinstance(i.input, float) for i in errors)
+        assert error_types == ["string_type", "string_type"]
+        assert errors_loc_marc == ["960$s", "960$s"]
 
 
-def test_MarcValidationError_string_type(stub_record):
-    stub_record["960"].delete_subfield("s")
-    stub_record["960"].add_subfield("s", 1.00)
-    with pytest.raises(ValidationError) as e:
-        RecordModel(leader=stub_record.leader, fields=stub_record.fields)
-    errors = MarcValidationError(e.value.errors()).to_dict()
-    assert errors["error_count"] == 2
-    assert errors["invalid_fields"][0] == {
-        "error_type": "Input should be a valid string. Examples: ['100', '200']",
-        "field": "960$s",
-        "input": 1.0,
-    }
-    assert errors["invalid_fields"][1] == {
-        "error_type": "Input should be a valid string. Examples: ['100', '200']",
-        "field": "960$s",
-        "input": 1.0,
-    }
-    assert len(errors["invalid_fields"]) == 2
-    assert len(errors["missing_fields"]) == 0
-    assert len(errors["extra_fields"]) == 0
-    assert len(errors["order_item_mismatches"]) == 0
+class TestMarcValidationErrorMonograph:
+    def test_MarcValidationError_literal_error(self, stub_record):
+        stub_record["960"].delete_subfield("t")
+        stub_record["960"].add_subfield("t", "foo")
+        with pytest.raises(ValidationError) as e:
+            RecordModel(leader=stub_record.leader, fields=stub_record.fields)
+        errors = MarcValidationError(e.value.errors()).to_dict()
+        assert errors["error_count"] == 1
+        assert errors["invalid_fields"] == [
+            {
+                "error_type": "Input should be: 'MAB', 'MAF', 'MAG', 'MAL', 'MAP', 'MAS', 'PAD', 'PAH', 'PAM', 'PAT' or 'SC'",
+                "field": "960$t",
+                "input": "foo",
+            },
+        ]
+        assert len(errors["invalid_fields"]) == 1
+        assert len(errors["missing_fields"]) == 0
+        assert len(errors["extra_fields"]) == 0
+        assert len(errors["order_item_mismatches"]) == 0
 
-
-def test_MarcValidationError_string_pattern(stub_record):
-    stub_record["960"].delete_subfield("s")
-    stub_record["960"].add_subfield("s", "1.00")
-    with pytest.raises(ValidationError) as e:
-        RecordModel(leader=stub_record.leader, fields=stub_record.fields)
-    errors = MarcValidationError(e.value.errors()).to_dict()
-    assert errors["error_count"] == 1
-    assert errors["invalid_fields"] == [
-        {
-            "error_type": "String should match pattern. Examples: ['100', '200']",
+    def test_MarcValidationError_string_type(self, stub_record):
+        stub_record["960"].delete_subfield("s")
+        stub_record["960"].add_subfield("s", 1.00)
+        with pytest.raises(ValidationError) as e:
+            RecordModel(leader=stub_record.leader, fields=stub_record.fields)
+        errors = MarcValidationError(e.value.errors()).to_dict()
+        assert errors["error_count"] == 2
+        assert errors["invalid_fields"][0] == {
+            "error_type": "Input should be a valid string. Examples: ['100', '200']",
             "field": "960$s",
-            "input": "1.00",
+            "input": 1.0,
         }
-    ]
-    assert len(errors["invalid_fields"]) == 1
-    assert len(errors["missing_fields"]) == 0
-    assert len(errors["extra_fields"]) == 0
-    assert len(errors["order_item_mismatches"]) == 0
-
-
-def test_MarcValidationError_extra_fields(stub_record):
-    record_dict = stub_record.as_dict()
-    record_dict["fields"].append(
-        {"003": {"ind1": " ", "ind2": " ", "subfields": [{"a": "foo"}]}}
-    )
-    with pytest.raises(ValidationError) as e:
-        RecordModel(**record_dict)
-    errors = MarcValidationError(e.value.errors()).to_dict()
-    assert errors["error_count"] == 4
-    assert len(errors["missing_fields"]) == 0
-    assert len(errors["invalid_fields"]) == 1
-    assert len(errors["extra_fields"]) == 3
-    assert len(errors["order_item_mismatches"]) == 0
-    assert errors["missing_fields"] == []
-    assert errors["invalid_fields"] == [
-        {
-            "field": "003",
-            "error_type": "Input should be a valid string. Examples: ['OCoLC', 'DLC']",
-            "input": {"ind1": " ", "ind2": " ", "subfields": [{"a": "foo"}]},
+        assert errors["invalid_fields"][1] == {
+            "error_type": "Input should be a valid string. Examples: ['100', '200']",
+            "field": "960$s",
+            "input": 1.0,
         }
-    ]
-    assert errors["extra_fields"] == ["003ind1", "003ind2", "003subfields"]
-    assert errors["order_item_mismatches"] == []
+        assert len(errors["invalid_fields"]) == 2
+        assert len(errors["missing_fields"]) == 0
+        assert len(errors["extra_fields"]) == 0
+        assert len(errors["order_item_mismatches"]) == 0
+
+    def test_MarcValidationError_string_pattern(self, stub_record):
+        stub_record["960"].delete_subfield("s")
+        stub_record["960"].add_subfield("s", "1.00")
+        with pytest.raises(ValidationError) as e:
+            RecordModel(leader=stub_record.leader, fields=stub_record.fields)
+        errors = MarcValidationError(e.value.errors()).to_dict()
+        assert errors["error_count"] == 1
+        assert errors["invalid_fields"] == [
+            {
+                "error_type": "String should match pattern. Examples: ['100', '200']",
+                "field": "960$s",
+                "input": "1.00",
+            }
+        ]
+        assert len(errors["invalid_fields"]) == 1
+        assert len(errors["missing_fields"]) == 0
+        assert len(errors["extra_fields"]) == 0
+        assert len(errors["order_item_mismatches"]) == 0
+
+    def test_MarcValidationError_extra_fields(self, stub_record):
+        record_dict = stub_record.as_dict()
+        record_dict["fields"].append(
+            {"003": {"ind1": " ", "ind2": " ", "subfields": [{"a": "foo"}]}}
+        )
+        with pytest.raises(ValidationError) as e:
+            RecordModel(**record_dict)
+        errors = MarcValidationError(e.value.errors()).to_dict()
+        assert errors["error_count"] == 4
+        assert len(errors["missing_fields"]) == 0
+        assert len(errors["invalid_fields"]) == 1
+        assert len(errors["extra_fields"]) == 3
+        assert len(errors["order_item_mismatches"]) == 0
+        assert errors["missing_fields"] == []
+        assert errors["invalid_fields"] == [
+            {
+                "field": "003",
+                "error_type": "Input should be a valid string. Examples: ['OCoLC', 'DLC']",
+                "input": {"ind1": " ", "ind2": " ", "subfields": [{"a": "foo"}]},
+            }
+        ]
+        assert errors["extra_fields"] == ["003ind1", "003ind2", "003subfields"]
+        assert errors["order_item_mismatches"] == []
+
+    def test_MarcValidationError_multiple_errors_order_item(self, stub_record):
+        stub_record.remove_fields("980")
+        stub_record["852"].delete_subfield("h")
+        stub_record["852"].add_subfield("h", "ReCAP-24-119100")
+        stub_record["960"].delete_subfield("t")
+        stub_record["960"].add_subfield("t", "PAH")
+        with pytest.raises(ValidationError) as e:
+            RecordModel(leader=stub_record.leader, fields=stub_record.fields)
+        errors = MarcValidationError(e.value.errors()).to_dict()
+        assert errors["error_count"] == 3
+        assert len(errors["missing_fields"]) == 1
+        assert len(errors["invalid_fields"]) == 1
+        assert len(errors["extra_fields"]) == 0
+        assert len(errors["order_item_mismatches"]) == 1
+        assert errors["missing_fields"] == ["980"]
+        assert errors["invalid_fields"] == [
+            {
+                "field": "852$h",
+                "input": "ReCAP-24-119100",
+                "error_type": "String should match pattern. Examples: ['ReCAP 23-000001', 'ReCAP 24-100001', 'ReCAP 25-222000']",
+            }
+        ]
+        assert errors["extra_fields"] == []
+        assert errors["order_item_mismatches"] == [("55", "rcmf2", "PAH")]
 
 
-def test_MarcValidationError_multiple_errors_order_item(stub_record):
-    stub_record.remove_fields("980")
-    stub_record["852"].delete_subfield("h")
-    stub_record["852"].add_subfield("h", "ReCAP-24-119100")
-    stub_record["960"].delete_subfield("t")
-    stub_record["960"].add_subfield("t", "PAH")
-    with pytest.raises(ValidationError) as e:
-        RecordModel(leader=stub_record.leader, fields=stub_record.fields)
-    errors = MarcValidationError(e.value.errors()).to_dict()
-    assert errors["error_count"] == 3
-    assert len(errors["missing_fields"]) == 1
-    assert len(errors["invalid_fields"]) == 1
-    assert len(errors["extra_fields"]) == 0
-    assert len(errors["order_item_mismatches"]) == 1
-    assert errors["missing_fields"] == ["980"]
-    assert errors["invalid_fields"] == [
-        {
-            "field": "852$h",
-            "input": "ReCAP-24-119100",
-            "error_type": "String should match pattern. Examples: ['ReCAP 23-000001', 'ReCAP 24-100001', 'ReCAP 25-222000']",
+class TestMarcValidationErrorOther:
+    def test_MarcValidationError_literal_error(self, stub_pamphlet_record):
+        stub_pamphlet_record["960"].delete_subfield("t")
+        stub_pamphlet_record["960"].add_subfield("t", "foo")
+        with pytest.raises(ValidationError) as e:
+            RecordModel(
+                leader=stub_pamphlet_record.leader, fields=stub_pamphlet_record.fields
+            )
+        errors = MarcValidationError(e.value.errors()).to_dict()
+        assert errors["error_count"] == 1
+        assert errors["invalid_fields"] == [
+            {
+                "error_type": "Input should be: 'MAB', 'MAF', 'MAG', 'MAL', 'MAP', 'MAS', 'PAD', 'PAH', 'PAM', 'PAT' or 'SC'",
+                "field": "960$t",
+                "input": "foo",
+            },
+        ]
+        assert len(errors["invalid_fields"]) == 1
+        assert len(errors["missing_fields"]) == 0
+        assert len(errors["extra_fields"]) == 0
+        assert len(errors["order_item_mismatches"]) == 0
+
+    def test_MarcValidationError_string_type(self, stub_pamphlet_record):
+        stub_pamphlet_record["960"].delete_subfield("s")
+        stub_pamphlet_record["960"].add_subfield("s", 1.00)
+        with pytest.raises(ValidationError) as e:
+            RecordModel(
+                leader=stub_pamphlet_record.leader, fields=stub_pamphlet_record.fields
+            )
+        errors = MarcValidationError(e.value.errors()).to_dict()
+        assert errors["error_count"] == 2
+        assert errors["invalid_fields"][0] == {
+            "error_type": "Input should be a valid string. Examples: ['100', '200']",
+            "field": "960$s",
+            "input": 1.0,
         }
-    ]
-    assert errors["extra_fields"] == []
-    assert errors["order_item_mismatches"] == [("55", "rcmf2", "PAH")]
+        assert errors["invalid_fields"][1] == {
+            "error_type": "Input should be a valid string. Examples: ['100', '200']",
+            "field": "960$s",
+            "input": 1.0,
+        }
+        assert len(errors["invalid_fields"]) == 2
+        assert len(errors["missing_fields"]) == 0
+        assert len(errors["extra_fields"]) == 0
+        assert len(errors["order_item_mismatches"]) == 0
+
+    def test_MarcValidationError_string_pattern(self, stub_pamphlet_record):
+        stub_pamphlet_record["960"].delete_subfield("s")
+        stub_pamphlet_record["960"].add_subfield("s", "1.00")
+        with pytest.raises(ValidationError) as e:
+            RecordModel(
+                leader=stub_pamphlet_record.leader, fields=stub_pamphlet_record.fields
+            )
+        errors = MarcValidationError(e.value.errors()).to_dict()
+        assert errors["error_count"] == 1
+        assert errors["invalid_fields"] == [
+            {
+                "error_type": "String should match pattern. Examples: ['100', '200']",
+                "field": "960$s",
+                "input": "1.00",
+            }
+        ]
+        assert len(errors["invalid_fields"]) == 1
+        assert len(errors["missing_fields"]) == 0
+        assert len(errors["extra_fields"]) == 0
+        assert len(errors["order_item_mismatches"]) == 0
+
+    def test_MarcValidationError_extra_fields(self, stub_record):
+        stub_record.remove_fields("300")
+        stub_record.add_field(
+            MarcField(
+                tag="300",
+                indicators=[" ", " "],
+                subfields=[
+                    Subfield(code="a", value="5 pages :"),
+                ],
+            )
+        )
+        with pytest.raises(ValidationError) as e:
+            RecordModel(leader=stub_record.leader, fields=stub_record.fields)
+        errors = MarcValidationError(e.value.errors()).to_dict()
+        assert errors["error_count"] == 2
+        assert len(errors["missing_fields"]) == 0
+        assert len(errors["invalid_fields"]) == 0
+        assert len(errors["extra_fields"]) == 2
+        assert len(errors["order_item_mismatches"]) == 0
+        assert errors["missing_fields"] == []
+        assert errors["invalid_fields"] == []
+        assert errors["extra_fields"] == ["852", "949"]
+        assert errors["order_item_mismatches"] == []
+
+    def test_MarcValidationError_multiple_errors(self, stub_pamphlet_record):
+        stub_pamphlet_record.remove_fields("980")
+        stub_pamphlet_record["960"].delete_subfield("t")
+        stub_pamphlet_record["960"].add_subfield("t", "FOO")
+        stub_pamphlet_record.add_field(
+            MarcField(
+                tag="852",
+                indicators=["8", " "],
+                subfields=[Subfield(code="h", value="ReCAP 24-119100")],
+            )
+        )
+        with pytest.raises(ValidationError) as e:
+            RecordModel(
+                leader=stub_pamphlet_record.leader, fields=stub_pamphlet_record.fields
+            )
+        errors = MarcValidationError(e.value.errors()).to_dict()
+        assert errors["error_count"] == 3
+        assert len(errors["missing_fields"]) == 1
+        assert len(errors["invalid_fields"]) == 1
+        assert len(errors["extra_fields"]) == 1
+        assert len(errors["order_item_mismatches"]) == 0
+        assert errors["missing_fields"] == ["980"]
+        assert errors["invalid_fields"] == [
+            {
+                "error_type": "Input should be: 'MAB', 'MAF', 'MAG', 'MAL', 'MAP', 'MAS', 'PAD', 'PAH', 'PAM', 'PAT' or 'SC'",
+                "field": "960$t",
+                "input": "FOO",
+            }
+        ]
+        assert errors["extra_fields"] == ["852"]
+        assert errors["order_item_mismatches"] == []

--- a/tests/test_marc_models.py
+++ b/tests/test_marc_models.py
@@ -6,396 +6,546 @@ from pymarc import Subfield, Leader, MARCReader
 from record_validator.marc_models import RecordModel
 
 
-def test_RecordModel_valid():
-    model = RecordModel(
-        leader="00000cam a2200000 a 4500",
-        fields=[
-            {"008": "200101s2001    xx      b    000 0 eng  d"},
-            {
-                "050": {
-                    "ind1": " ",
-                    "ind2": "4",
-                    "subfields": [{"a": "F00"}, {"b": ".F00"}],
-                }
-            },
-            {"245": {"ind1": "0", "ind2": "0", "subfields": [{"a": "The Title"}]}},
-            {
-                "852": {
-                    "ind1": "8",
-                    "ind2": " ",
-                    "subfields": [{"h": "ReCAP 24-111111"}],
-                }
-            },
-            {"901": {"ind1": " ", "ind2": " ", "subfields": [{"a": "EVP"}]}},
-            {"910": {"ind1": " ", "ind2": " ", "subfields": [{"a": "RL"}]}},
-            {
-                "960": {
-                    "ind1": " ",
-                    "ind2": " ",
-                    "subfields": [{"s": "100"}, {"t": "MAL"}, {"u": "123456apprv"}],
-                }
-            },
-            {
-                "980": {
-                    "ind1": " ",
-                    "ind2": " ",
-                    "subfields": [
-                        {"a": "240101"},
-                        {"b": "100"},
-                        {"c": "0"},
-                        {"d": "0"},
-                        {"f": "1"},
-                        {"e": "100"},
-                        {"g": "1"},
-                    ],
-                }
-            },
-            {
-                "949": {
-                    "ind1": " ",
-                    "ind2": "1",
-                    "subfields": [
-                        {"z": "8528"},
-                        {"a": "ReCAP 24-111111"},
-                        {"i": "33433123456789"},
-                        {"p": "1.00"},
-                        {"v": "EVP"},
-                        {"h": "43"},
-                        {"l": "rc2ma"},
-                        {"t": "55"},
-                        {"c": "1"},
-                        {"u": "foo"},
-                        {"m": "bar"},
-                    ],
-                }
-            },
-        ],
-    )
-    assert list(model.model_dump().keys()) == ["leader", "fields"]
-
-
-def test_RecordModel_from_marc_valid(stub_record):
-    record_1 = stub_record
-    record_2 = stub_record.as_marc21()
-    reader = MARCReader(record_2)
-    record_2 = next(reader)
-    assert isinstance(record_1.leader, str)
-    assert isinstance(record_2.leader, Leader)
-    model_1 = RecordModel(leader=record_1.leader, fields=record_1.fields)
-    model_2 = RecordModel(leader=record_2.leader, fields=record_2.fields)
-    assert model_1.model_dump().keys() == model_2.model_dump().keys()
-
-
-def test_RecordModel_from_marc_dict_valid(stub_record):
-    record_dict = stub_record.as_dict()
-    with does_not_raise():
-        RecordModel(**record_dict)
-
-
-def test_RecordModel_from_marc_multiple_items(stub_record):
-    stub_record.add_field(
-        MarcField(
-            tag="949",
-            indicators=[" ", "1"],
-            subfields=[
-                Subfield(code="z", value="8528"),
-                Subfield(code="a", value="ReCAP 24-000000"),
-                Subfield(code="i", value="33433123456789"),
-                Subfield(code="p", value="1.00"),
-                Subfield(code="v", value="EVP"),
-                Subfield(code="h", value="43"),
-                Subfield(code="l", value="rcmf2"),
-                Subfield(code="t", value="55"),
+class TestRecordModelMonograph:
+    def test_RecordModel_valid(self):
+        model = RecordModel(
+            leader="00000cam a2200000 a 4500",
+            fields=[
+                {"008": "200101s2001    xx      b    000 0 eng  d"},
+                {
+                    "050": {
+                        "ind1": " ",
+                        "ind2": "4",
+                        "subfields": [{"a": "F00"}, {"b": ".F00"}],
+                    }
+                },
+                {"245": {"ind1": "0", "ind2": "0", "subfields": [{"a": "The Title"}]}},
+                {"300": {"ind1": " ", "ind2": " ", "subfields": [{"a": "100 pages"}]}},
+                {
+                    "852": {
+                        "ind1": "8",
+                        "ind2": " ",
+                        "subfields": [{"h": "ReCAP 24-111111"}],
+                    }
+                },
+                {"901": {"ind1": " ", "ind2": " ", "subfields": [{"a": "EVP"}]}},
+                {"910": {"ind1": " ", "ind2": " ", "subfields": [{"a": "RL"}]}},
+                {
+                    "960": {
+                        "ind1": " ",
+                        "ind2": " ",
+                        "subfields": [{"s": "100"}, {"t": "MAL"}, {"u": "123456apprv"}],
+                    }
+                },
+                {
+                    "980": {
+                        "ind1": " ",
+                        "ind2": " ",
+                        "subfields": [
+                            {"a": "240101"},
+                            {"b": "100"},
+                            {"c": "0"},
+                            {"d": "0"},
+                            {"f": "1"},
+                            {"e": "100"},
+                            {"g": "1"},
+                        ],
+                    }
+                },
+                {
+                    "949": {
+                        "ind1": " ",
+                        "ind2": "1",
+                        "subfields": [
+                            {"z": "8528"},
+                            {"a": "ReCAP 24-111111"},
+                            {"i": "33433123456789"},
+                            {"p": "1.00"},
+                            {"v": "EVP"},
+                            {"h": "43"},
+                            {"l": "rc2ma"},
+                            {"t": "55"},
+                            {"c": "1"},
+                            {"u": "foo"},
+                            {"m": "bar"},
+                        ],
+                    }
+                },
             ],
         )
+        assert list(model.model_dump().keys()) == ["leader", "fields"]
+
+    def test_RecordModel_from_marc_str_leader(self, stub_record):
+        assert isinstance(stub_record.leader, str)
+        model = RecordModel(leader=stub_record.leader, fields=stub_record.fields)
+        assert list(model.model_dump().keys()) == ["leader", "fields"]
+
+    def test_RecordModel_from_marc_leader(self, stub_record):
+        record = stub_record.as_marc21()
+        reader = MARCReader(record)
+        record = next(reader)
+        assert isinstance(record.leader, Leader)
+        model = RecordModel(leader=record.leader, fields=record.fields)
+        assert list(model.model_dump().keys()) == ["leader", "fields"]
+
+    def test_RecordModel_from_marc_dict_valid(self, stub_record):
+        record_dict = stub_record.as_dict()
+        with does_not_raise():
+            RecordModel(**record_dict)
+
+    def test_RecordModel_from_marc_multiple_items(self, stub_record):
+        stub_record.add_field(
+            MarcField(
+                tag="949",
+                indicators=[" ", "1"],
+                subfields=[
+                    Subfield(code="z", value="8528"),
+                    Subfield(code="a", value="ReCAP 24-000000"),
+                    Subfield(code="i", value="33433123456789"),
+                    Subfield(code="p", value="1.00"),
+                    Subfield(code="v", value="EVP"),
+                    Subfield(code="h", value="43"),
+                    Subfield(code="l", value="rcmf2"),
+                    Subfield(code="t", value="55"),
+                ],
+            )
+        )
+        with does_not_raise():
+            RecordModel(leader=stub_record.leader, fields=stub_record.fields)
+
+    def test_RecordModel_from_marc_dict_multiple_items(self, stub_record):
+        stub_record.add_field(
+            MarcField(
+                tag="949",
+                indicators=[" ", "1"],
+                subfields=[
+                    Subfield(code="z", value="8528"),
+                    Subfield(code="a", value="ReCAP 24-000000"),
+                    Subfield(code="i", value="33433123456789"),
+                    Subfield(code="p", value="1.00"),
+                    Subfield(code="v", value="EVP"),
+                    Subfield(code="h", value="43"),
+                    Subfield(code="l", value="rcmf2"),
+                    Subfield(code="t", value="55"),
+                ],
+            )
+        )
+        record_dict = stub_record.as_dict()
+        with does_not_raise():
+            RecordModel(**record_dict)
+
+    def test_RecordModel_from_marc_invalid(self, stub_record):
+        stub_record.remove_fields("901", "852")
+        stub_record.add_field(
+            MarcField(
+                tag="852",
+                indicators=["8", " "],
+                subfields=[Subfield(code="h", value="foo")],
+            )
+        )
+        with pytest.raises(ValidationError) as e:
+            RecordModel(leader=stub_record.leader, fields=stub_record.fields)
+        assert len(e.value.errors()) == 2
+        assert sorted([i["type"] for i in e.value.errors()]) == sorted(
+            ["missing", "string_pattern_mismatch"]
+        )
+
+    def test_RecordModel_invalid(self):
+        record_dict = {
+            "leader": "00000cam a2200000 a 4500",
+            "fields": [
+                {"245": {"ind1": "0", "ind2": "0", "subfields": [{"a": "The Title"}]}},
+                {
+                    "852": {
+                        "ind1": "8",
+                        "ind2": " ",
+                        "subfields": [{"h": "foo"}],
+                    }
+                },
+                {"901": {"ind1": " ", "ind2": " ", "subfields": [{"a": "EVP"}]}},
+                {"910": {"ind1": " ", "ind2": " ", "subfields": [{"a": "RL"}]}},
+                {
+                    "960": {
+                        "ind1": " ",
+                        "ind2": " ",
+                        "subfields": [{"s": "100"}, {"t": "bar"}, {"u": "123456apprv"}],
+                    }
+                },
+                {
+                    "980": {
+                        "ind1": " ",
+                        "ind2": " ",
+                        "subfields": [
+                            {"a": "240101"},
+                            {"b": "100"},
+                            {"c": "0"},
+                            {"d": "0"},
+                            {"f": "1"},
+                            {"e": "100"},
+                            {"g": "1"},
+                        ],
+                    }
+                },
+                {
+                    "949": {
+                        "ind1": " ",
+                        "ind2": "1",
+                        "subfields": [
+                            {"z": "8528"},
+                            {"a": "ReCAP 24-111111"},
+                            {"i": "33433123456789"},
+                            {"p": "1.00"},
+                            {"v": "EVP"},
+                            {"h": "43"},
+                            {"l": "rc2ma"},
+                            {"t": "55"},
+                            {"c": "1"},
+                            {"u": "foo"},
+                            {"m": "bar"},
+                        ],
+                    }
+                },
+            ],
+        }
+        with pytest.raises(ValidationError) as e:
+            RecordModel(**record_dict)
+        assert len(e.value.errors()) == 3
+        assert sorted([i["type"] for i in e.value.errors()]) == sorted(
+            ["literal_error", "string_pattern_mismatch", "missing"]
+        )
+
+    def test_RecordModel_missing_field(self, stub_record):
+        stub_record.remove_fields("852")
+        with pytest.raises(ValidationError) as e:
+            RecordModel(leader=stub_record.leader, fields=stub_record.fields)
+        assert len(e.value.errors()) == 1
+        assert [i["type"] for i in e.value.errors()] == ["missing"]
+
+    def test_RecordModel_string_pattern_mismatch(self, stub_record):
+        stub_record.remove_fields("852")
+        stub_record.add_field(
+            MarcField(
+                tag="852",
+                indicators=["8", " "],
+                subfields=[Subfield(code="h", value="foo")],
+            )
+        )
+        with pytest.raises(ValidationError) as e:
+            RecordModel(leader=stub_record.leader, fields=stub_record.fields)
+        assert len(e.value.errors()) == 1
+        assert [i["type"] for i in e.value.errors()] == ["string_pattern_mismatch"]
+
+    def test_RecordModel_literal_error(self, stub_record):
+        stub_record.remove_fields("901")
+        stub_record.add_field(
+            MarcField(
+                tag="901",
+                indicators=[" ", " "],
+                subfields=[Subfield(code="a", value="foo")],
+            )
+        )
+        with pytest.raises(ValidationError) as e:
+            RecordModel(leader=stub_record.leader, fields=stub_record.fields)
+        assert len(e.value.errors()) == 1
+        assert [i["type"] for i in e.value.errors()] == ["literal_error"]
+
+    @pytest.mark.parametrize(
+        "leader_value, leader_error",
+        [
+            ("foo", "string_too_short"),
+            ("bar", "string_too_short"),
+            ("foobarfoobarfoobarfoobar", "string_pattern_mismatch"),
+        ],
     )
-    with does_not_raise():
-        RecordModel(leader=stub_record.leader, fields=stub_record.fields)
+    def test_RecordModel_invalid_leader(
+        self,
+        stub_record,
+        leader_value,
+        leader_error,
+    ):
+        record_dict = stub_record.as_dict()
+        record_dict["leader"] = leader_value
+        with pytest.raises(ValidationError) as e:
+            RecordModel(**record_dict)
+        assert len(e.value.errors()) == 1
+        assert e.value.errors()[0]["type"] == leader_error
+
+    @pytest.mark.parametrize(
+        "fields_value",
+        [{}, None],
+    )
+    def test_RecordModel_invalid_fields(
+        self,
+        stub_record,
+        fields_value,
+    ):
+        record_dict = stub_record.as_dict()
+        record_dict["fields"] = fields_value
+        with pytest.raises(ValidationError) as e:
+            RecordModel(**record_dict)
+        assert len(e.value.errors()) == 2
+        assert e.value.errors()[0]["type"] == "list_type"
+
+    @pytest.mark.parametrize(
+        "order_location_value,item_location_value,item_type_value,",
+        [
+            ("MAL", "rc2ma", "55"),
+            ("MAL", None, None),
+            ("MAL", None, "55"),
+            ("MAL", "rc2ma", None),
+            ("MAB", "rcmb2", "2"),
+            ("MAS", "rcmb2", "2"),
+            ("MAF", "rcmf2", "55"),
+            ("MAF", "rcmf2", None),
+            ("MAG", "rcmg2", "55"),
+            ("MAG", "rcmg2", None),
+        ],
+    )
+    def test_RecordModel_valid_location_combos(
+        self, stub_record, order_location_value, item_location_value, item_type_value
+    ):
+        stub_record["949"].delete_subfield("l")
+        stub_record["949"].delete_subfield("t")
+        stub_record["960"].delete_subfield("t")
+        stub_record["960"].add_subfield("t", order_location_value)
+        if item_location_value is not None:
+            stub_record["949"].add_subfield("l", item_location_value)
+        if item_type_value is not None:
+            stub_record["949"].add_subfield("t", item_type_value)
+        with does_not_raise():
+            RecordModel(leader=stub_record.leader, fields=stub_record.fields)
+
+    def test_RecordModel_order_item_data_not_checked(self, stub_record):
+        stub_record["949"].delete_subfield("t")
+        stub_record["949"].add_subfield("t", "2")
+        stub_record["960"].delete_subfield("t")
+        with pytest.raises(ValidationError) as e:
+            RecordModel(leader=stub_record.leader, fields=stub_record.fields)
+        error_types = [error["type"] for error in e.value.errors()]
+        assert len(e.value.errors()) == 1
+        assert "order_item_mismatch" not in error_types
+        assert error_types == ["missing"]
+
+    @pytest.mark.parametrize(
+        "order_location_value,item_location_value,item_type_value,",
+        [
+            ("MAB", "rc2ma", "55"),
+            ("MAS", None, None),
+            ("MAG", "rcmf2", "55"),
+            ("MAF", "rc2ma", None),
+            ("MAL", "rcmg2", "55"),
+        ],
+    )
+    def test_RecordModel_invalid_order_item_data(
+        self, stub_record, order_location_value, item_location_value, item_type_value
+    ):
+        stub_record["949"].delete_subfield("l")
+        stub_record["949"].delete_subfield("t")
+        stub_record["960"].delete_subfield("t")
+        stub_record["960"].add_subfield("t", order_location_value)
+        if item_location_value is not None:
+            stub_record["949"].add_subfield("l", item_location_value)
+        if item_type_value is not None:
+            stub_record["949"].add_subfield("t", item_type_value)
+        with pytest.raises(ValidationError) as e:
+            RecordModel(leader=stub_record.leader, fields=stub_record.fields)
+        assert len(e.value.errors()) == 1
+        assert e.value.errors()[0]["type"] == "order_item_mismatch"
+
+    def test_RecordModel_invalid_order_item_data_multiple(
+        self,
+        stub_record_multiple_items,
+    ):
+        stub_record_multiple_items["949"].delete_subfield("l")
+        stub_record_multiple_items["949"].add_subfield("l", "rcmg2")
+        stub_record_multiple_items["960"].delete_subfield("t")
+        stub_record_multiple_items["960"].add_subfield("t", "MAP")
+        with pytest.raises(ValidationError) as e:
+            RecordModel(
+                leader=stub_record_multiple_items.leader,
+                fields=stub_record_multiple_items.fields,
+            )
+        assert len(e.value.errors()) == 2
+        assert e.value.errors()[0]["type"] == "order_item_mismatch"
 
 
-def test_RecordModel_from_marc_dict_multiple_items(stub_record):
-    stub_record.add_field(
-        MarcField(
-            tag="949",
-            indicators=[" ", "1"],
-            subfields=[
-                Subfield(code="z", value="8528"),
-                Subfield(code="a", value="ReCAP 24-000000"),
-                Subfield(code="i", value="33433123456789"),
-                Subfield(code="p", value="1.00"),
-                Subfield(code="v", value="EVP"),
-                Subfield(code="h", value="43"),
-                Subfield(code="l", value="rcmf2"),
-                Subfield(code="t", value="55"),
+class TestRecordModelOther:
+    def test_RecordModel_valid(self):
+        model = RecordModel(
+            leader="00000cam a2200000 a 4500",
+            fields=[
+                {"008": "200101s2001    xx      b    000 0 eng  d"},
+                {
+                    "050": {
+                        "ind1": " ",
+                        "ind2": "4",
+                        "subfields": [{"a": "F00"}, {"b": ".F00"}],
+                    }
+                },
+                {"245": {"ind1": "0", "ind2": "0", "subfields": [{"a": "The Title"}]}},
+                {"300": {"ind1": " ", "ind2": " ", "subfields": [{"a": "5 pages"}]}},
+                {"901": {"ind1": " ", "ind2": " ", "subfields": [{"a": "EVP"}]}},
+                {"910": {"ind1": " ", "ind2": " ", "subfields": [{"a": "RL"}]}},
+                {
+                    "960": {
+                        "ind1": " ",
+                        "ind2": " ",
+                        "subfields": [{"s": "100"}, {"t": "MAL"}, {"u": "123456apprv"}],
+                    }
+                },
+                {
+                    "980": {
+                        "ind1": " ",
+                        "ind2": " ",
+                        "subfields": [
+                            {"a": "240101"},
+                            {"b": "100"},
+                            {"c": "0"},
+                            {"d": "0"},
+                            {"f": "1"},
+                            {"e": "100"},
+                            {"g": "1"},
+                        ],
+                    }
+                },
             ],
         )
-    )
-    record_dict = stub_record.as_dict()
-    with does_not_raise():
-        RecordModel(**record_dict)
+        assert list(model.model_dump().keys()) == ["leader", "fields"]
 
-
-def test_RecordModel_from_marc_invalid(stub_record):
-    stub_record.remove_fields("901", "852")
-    stub_record.add_field(
-        MarcField(
-            tag="852",
-            indicators=["8", " "],
-            subfields=[Subfield(code="h", value="foo")],
+    def test_RecordModel_from_marc_str_leader(self, stub_pamphlet_record):
+        assert isinstance(stub_pamphlet_record.leader, str)
+        model = RecordModel(
+            leader=stub_pamphlet_record.leader, fields=stub_pamphlet_record.fields
         )
-    )
-    with pytest.raises(ValidationError) as e:
-        RecordModel(leader=stub_record.leader, fields=stub_record.fields)
-    assert len(e.value.errors()) == 2
-    assert sorted([i["type"] for i in e.value.errors()]) == sorted(
-        ["missing", "string_pattern_mismatch"]
-    )
+        assert list(model.model_dump().keys()) == ["leader", "fields"]
 
+    def test_RecordModel_from_marc_leader(self, stub_pamphlet_record):
+        record = stub_pamphlet_record.as_marc21()
+        reader = MARCReader(record)
+        record = next(reader)
+        assert isinstance(record.leader, Leader)
+        model = RecordModel(leader=record.leader, fields=record.fields)
+        assert list(model.model_dump().keys()) == ["leader", "fields"]
 
-def test_RecordModel_invalid():
-    record_dict = {
-        "leader": "00000cam a2200000 a 4500",
-        "fields": [
-            {"245": {"ind1": "0", "ind2": "0", "subfields": [{"a": "The Title"}]}},
-            {
-                "852": {
-                    "ind1": "8",
-                    "ind2": " ",
-                    "subfields": [{"h": "foo"}],
-                }
-            },
-            {"901": {"ind1": " ", "ind2": " ", "subfields": [{"a": "EVP"}]}},
-            {"910": {"ind1": " ", "ind2": " ", "subfields": [{"a": "RL"}]}},
-            {
-                "960": {
-                    "ind1": " ",
-                    "ind2": " ",
-                    "subfields": [{"s": "100"}, {"t": "bar"}, {"u": "123456apprv"}],
-                }
-            },
-            {
-                "980": {
-                    "ind1": " ",
-                    "ind2": " ",
-                    "subfields": [
-                        {"a": "240101"},
-                        {"b": "100"},
-                        {"c": "0"},
-                        {"d": "0"},
-                        {"f": "1"},
-                        {"e": "100"},
-                        {"g": "1"},
-                    ],
-                }
-            },
-            {
-                "949": {
-                    "ind1": " ",
-                    "ind2": "1",
-                    "subfields": [
-                        {"z": "8528"},
-                        {"a": "ReCAP 24-111111"},
-                        {"i": "33433123456789"},
-                        {"p": "1.00"},
-                        {"v": "EVP"},
-                        {"h": "43"},
-                        {"l": "rc2ma"},
-                        {"t": "55"},
-                        {"c": "1"},
-                        {"u": "foo"},
-                        {"m": "bar"},
-                    ],
-                }
-            },
+    def test_RecordModel_from_marc_dict_valid(self, stub_pamphlet_record):
+        record_dict = stub_pamphlet_record.as_dict()
+        with does_not_raise():
+            RecordModel(**record_dict)
+
+    def test_RecordModel_invalid(self):
+        record_dict = {
+            "leader": "00000cam a2200000 a 4500",
+            "fields": [
+                {"008": "200101s2001    xx      b    000 0 eng  d"},
+                {
+                    "050": {
+                        "ind1": " ",
+                        "ind2": "4",
+                        "subfields": [{"a": "F00"}, {"b": ".F00"}],
+                    }
+                },
+                {"245": {"ind1": "0", "ind2": "0", "subfields": [{"a": "The Title"}]}},
+                {"300": {"ind1": " ", "ind2": " ", "subfields": [{"a": "5 pages"}]}},
+                {"901": {"ind1": " ", "ind2": " ", "subfields": [{"a": "FOO"}]}},
+                {"910": {"ind1": " ", "ind2": " ", "subfields": [{"a": "RL"}]}},
+                {
+                    "960": {
+                        "ind1": " ",
+                        "ind2": " ",
+                        "subfields": [{"s": "100"}, {"t": "MAL"}, {"u": "123456apprv"}],
+                    }
+                },
+                {
+                    "980": {
+                        "ind1": " ",
+                        "ind2": " ",
+                        "subfields": [
+                            {"a": "240101"},
+                            {"b": "1.00"},
+                            {"c": "0"},
+                            {"d": "0"},
+                            {"f": "1"},
+                            {"e": "100"},
+                        ],
+                    }
+                },
+            ],
+        }
+        with pytest.raises(ValidationError) as e:
+            RecordModel(**record_dict)
+        assert len(e.value.errors()) == 3
+        assert sorted([i["type"] for i in e.value.errors()]) == sorted(
+            ["literal_error", "string_pattern_mismatch", "missing"]
+        )
+
+    def test_RecordModel_missing_field(self, stub_pamphlet_record):
+        stub_pamphlet_record.remove_fields("901")
+        with pytest.raises(ValidationError) as e:
+            RecordModel(
+                leader=stub_pamphlet_record.leader, fields=stub_pamphlet_record.fields
+            )
+        assert len(e.value.errors()) == 1
+        assert [i["type"] for i in e.value.errors()] == ["missing"]
+
+    def test_RecordModel_string_pattern_mismatch(self, stub_pamphlet_record):
+        stub_pamphlet_record["960"].delete_subfield("s")
+        stub_pamphlet_record["960"].add_subfield("s", "1.00")
+        with pytest.raises(ValidationError) as e:
+            RecordModel(
+                leader=stub_pamphlet_record.leader, fields=stub_pamphlet_record.fields
+            )
+        assert len(e.value.errors()) == 1
+        assert [i["type"] for i in e.value.errors()] == ["string_pattern_mismatch"]
+
+    def test_RecordModel_literal_error(self, stub_pamphlet_record):
+        stub_pamphlet_record.remove_fields("901")
+        stub_pamphlet_record.add_field(
+            MarcField(
+                tag="901",
+                indicators=[" ", " "],
+                subfields=[Subfield(code="a", value="foo")],
+            )
+        )
+        with pytest.raises(ValidationError) as e:
+            RecordModel(
+                leader=stub_pamphlet_record.leader, fields=stub_pamphlet_record.fields
+            )
+        assert len(e.value.errors()) == 1
+        assert [i["type"] for i in e.value.errors()] == ["literal_error"]
+
+    @pytest.mark.parametrize(
+        "leader_value, leader_error",
+        [
+            ("foo", "string_too_short"),
+            ("bar", "string_too_short"),
+            ("foobarfoobarfoobarfoobar", "string_pattern_mismatch"),
         ],
-    }
-    with pytest.raises(ValidationError) as e:
-        RecordModel(**record_dict)
-    assert len(e.value.errors()) == 3
-    assert sorted([i["type"] for i in e.value.errors()]) == sorted(
-        ["literal_error", "string_pattern_mismatch", "missing"]
     )
+    def test_RecordModel_invalid_leader(
+        self,
+        stub_pamphlet_record,
+        leader_value,
+        leader_error,
+    ):
+        record_dict = stub_pamphlet_record.as_dict()
+        record_dict["leader"] = leader_value
+        with pytest.raises(ValidationError) as e:
+            RecordModel(**record_dict)
+        assert len(e.value.errors()) == 1
+        assert e.value.errors()[0]["type"] == leader_error
 
-
-def test_RecordModel_missing_field(stub_record):
-    stub_record.remove_fields("852")
-    with pytest.raises(ValidationError) as e:
-        RecordModel(leader=stub_record.leader, fields=stub_record.fields)
-    assert len(e.value.errors()) == 1
-    assert sorted([i["type"] for i in e.value.errors()]) == sorted(["missing"])
-
-
-def test_RecordModel_string_pattern_mismatch(stub_record):
-    stub_record.remove_fields("852")
-    stub_record.add_field(
-        MarcField(
-            tag="852",
-            indicators=["8", " "],
-            subfields=[Subfield(code="h", value="foo")],
-        )
+    @pytest.mark.parametrize(
+        "fields_value",
+        [{}, None],
     )
-    with pytest.raises(ValidationError) as e:
-        RecordModel(leader=stub_record.leader, fields=stub_record.fields)
-    assert len(e.value.errors()) == 1
-    assert sorted([i["type"] for i in e.value.errors()]) == sorted(
-        ["string_pattern_mismatch"]
-    )
-
-
-def test_RecordModel_literal_error(stub_record):
-    stub_record.remove_fields("901")
-    stub_record.add_field(
-        MarcField(
-            tag="901",
-            indicators=[" ", " "],
-            subfields=[Subfield(code="a", value="foo")],
-        )
-    )
-    with pytest.raises(ValidationError) as e:
-        RecordModel(leader=stub_record.leader, fields=stub_record.fields)
-    assert len(e.value.errors()) == 1
-    assert sorted([i["type"] for i in e.value.errors()]) == sorted(["literal_error"])
-
-
-@pytest.mark.parametrize(
-    "leader_value, leader_error",
-    [
-        ("foo", "string_too_short"),
-        ("bar", "string_too_short"),
-        ("foobarfoobarfoobarfoobar", "string_pattern_mismatch"),
-    ],
-)
-def test_RecordModel_invalid_leader(
-    stub_record,
-    leader_value,
-    leader_error,
-):
-    record_dict = stub_record.as_dict()
-    record_dict["leader"] = leader_value
-    with pytest.raises(ValidationError) as e:
-        RecordModel(**record_dict)
-    assert len(e.value.errors()) == 1
-    assert e.value.errors()[0]["type"] == leader_error
-
-
-@pytest.mark.parametrize(
-    "fields_value",
-    [{}, None],
-)
-def test_RecordModel_invalid_fields(
-    stub_record,
-    fields_value,
-):
-    record_dict = stub_record.as_dict()
-    record_dict["fields"] = fields_value
-    with pytest.raises(ValidationError) as e:
-        RecordModel(**record_dict)
-    assert len(e.value.errors()) == 2
-    assert e.value.errors()[0]["type"] == "list_type"
-
-
-@pytest.mark.parametrize(
-    "order_location_value,item_location_value,item_type_value,",
-    [
-        ("MAL", "rc2ma", "55"),
-        ("MAL", None, None),
-        ("MAL", None, "55"),
-        ("MAL", "rc2ma", None),
-        ("MAB", "rcmb2", "2"),
-        ("MAS", "rcmb2", "2"),
-        ("MAF", "rcmf2", "55"),
-        ("MAF", "rcmf2", None),
-        ("MAG", "rcmg2", "55"),
-        ("MAG", "rcmg2", None),
-    ],
-)
-def test_RecordModel_valid_location_combos(
-    stub_record, order_location_value, item_location_value, item_type_value
-):
-    stub_record["949"].delete_subfield("l")
-    stub_record["949"].delete_subfield("t")
-    stub_record["960"].delete_subfield("t")
-    stub_record["960"].add_subfield("t", order_location_value)
-    if item_location_value is not None:
-        stub_record["949"].add_subfield("l", item_location_value)
-    if item_type_value is not None:
-        stub_record["949"].add_subfield("t", item_type_value)
-    with does_not_raise():
-        RecordModel(leader=stub_record.leader, fields=stub_record.fields)
-
-
-def test_RecordModel_order_item_data_not_checked(stub_record):
-    stub_record["949"].delete_subfield("t")
-    stub_record["949"].add_subfield("t", "2")
-    stub_record["960"].delete_subfield("t")
-    with pytest.raises(ValidationError) as e:
-        RecordModel(leader=stub_record.leader, fields=stub_record.fields)
-    error_types = [error["type"] for error in e.value.errors()]
-    assert len(e.value.errors()) == 1
-    assert "order_item_mismatch" not in error_types
-    assert error_types == ["missing"]
-
-
-@pytest.mark.parametrize(
-    "order_location_value,item_location_value,item_type_value,",
-    [
-        ("MAB", "rc2ma", "55"),
-        ("MAS", None, None),
-        ("MAG", "rcmf2", "55"),
-        ("MAF", "rc2ma", None),
-        ("MAL", "rcmg2", "55"),
-    ],
-)
-def test_RecordModel_invalid_order_item_data(
-    stub_record, order_location_value, item_location_value, item_type_value
-):
-    stub_record["949"].delete_subfield("l")
-    stub_record["949"].delete_subfield("t")
-    stub_record["960"].delete_subfield("t")
-    stub_record["960"].add_subfield("t", order_location_value)
-    if item_location_value is not None:
-        stub_record["949"].add_subfield("l", item_location_value)
-    if item_type_value is not None:
-        stub_record["949"].add_subfield("t", item_type_value)
-    with pytest.raises(ValidationError) as e:
-        RecordModel(leader=stub_record.leader, fields=stub_record.fields)
-    assert len(e.value.errors()) == 1
-    assert e.value.errors()[0]["type"] == "order_item_mismatch"
-
-
-def test_RecordModel_invalid_order_item_data_multiple(stub_record, stub_item):
-    stub_record["949"].delete_subfield("l")
-    stub_record["949"].add_subfield("l", "rcmg2")
-    stub_record["960"].delete_subfield("t")
-    stub_record["960"].add_subfield("t", "MAP")
-    stub_record.add_field(stub_item)
-    with pytest.raises(ValidationError) as e:
-        RecordModel(leader=stub_record.leader, fields=stub_record.fields)
-    assert len(e.value.errors()) == 2
-    assert e.value.errors()[0]["type"] == "order_item_mismatch"
-
-
-# def test_RecordModel_invalid_material_type(
-#     mock_bib_call_no,
-#     mock_bib_vendor_code,
-#     mock_lc_class,
-#     mock_library,
-#     mock_order_field,
-#     mock_invoice_field,
-#     mock_item_fields,
-# ):
-#     with pytest.raises(ValidationError) as e:
-#         RecordModel(
-#             leader="00000cam a2200000 a 4500",
-#             fields=[{"245": {"a": "The Title"}}],
-#             bib_call_no=mock_bib_call_no,
-#             bib_vendor_code=mock_bib_vendor_code,
-#             lc_class=mock_lc_class,
-#             library_field=mock_library,
-#             material_type=None,
-#             order_field=mock_order_field,
-#             invoice_field=mock_invoice_field,
-#             item_fields=mock_item_fields,
-#         )
-#     assert len(e.value.errors()) == 1
-#     assert e.value.errors()[0]["type"] == "literal_error"
+    def test_RecordModel_invalid_fields(
+        self,
+        stub_pamphlet_record,
+        fields_value,
+    ):
+        record_dict = stub_pamphlet_record.as_dict()
+        record_dict["fields"] = fields_value
+        with pytest.raises(ValidationError) as e:
+            RecordModel(**record_dict)
+        assert len(e.value.errors()) == 2
+        assert e.value.errors()[0]["type"] == "list_type"

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -58,14 +58,14 @@ def test_get_order_item_list_marc(stub_record):
     assert sorted([i["item_location"] for i in parsed_data]) == sorted(["rcmf2"])
 
 
-def test_get_order_item_list_multiple(stub_record_with_dupes):
-    fields = stub_record_with_dupes.fields
+def test_get_order_item_list_multiple(stub_record_multiple_items):
+    fields = stub_record_multiple_items.fields
     parsed_data = get_order_item_list(fields)
     assert len(parsed_data) == 2
     assert [i["item_type"] for i in parsed_data] == ["55", "55"]
     assert [i["order_location"] for i in parsed_data] == ["MAF", "MAF"]
     assert sorted([i["item_location"] for i in parsed_data]) == sorted(
-        ["rcmf2", "rc2ma"]
+        ["rcmf2", "rcmf2"]
     )
 
 
@@ -93,9 +93,8 @@ def test_get_order_item_list_dict(stub_record):
     assert sorted([i["item_location"] for i in parsed_data]) == sorted(["rcmf2"])
 
 
-def test_get_order_item_list_dict_multiple(stub_record, stub_item):
-    stub_record.add_field(stub_item)
-    stub_record_dict = stub_record.as_dict()
+def test_get_order_item_list_dict_multiple(stub_record_multiple_items):
+    stub_record_dict = stub_record_multiple_items.as_dict()
     fields = stub_record_dict["fields"]
     parsed_data = get_order_item_list(fields)
     item_fields = [i for i in fields if "949" in i]


### PR DESCRIPTION
Fixed
 - error in `MarcError` that caused location of extra fields to not added to `MarcError.extra_fields` attribute

Added
 - tests for monograph and other material types