### PR TITLE
Item agency fixes

### DIFF
--- a/record_validator/field_models.py
+++ b/record_validator/field_models.py
@@ -373,8 +373,8 @@ class ItemField(BaseDataField):
 
     @model_validator(mode="after")
     def validate_item_agency(self) -> "ItemField":
-        error_msg = "Invalid Item Agency. Item Agency is required for"
-        if self.item_agency is None and self.item_location != "rc2ma":
+        error_msg = "Invalid Item Agency for item location:"
+        if self.item_agency is None and self.item_location not in ["rc2ma", None]:
             raise ValueError(f"{error_msg} {self.item_location}")
         else:
             return self

--- a/tests/test_field_models.py
+++ b/tests/test_field_models.py
@@ -1302,7 +1302,7 @@ def test_ItemField_invalid_item_location_with_agency(item_location_value):
     assert e.value.errors()[0]["type"] == "value_error"
     assert (
         e.value.errors()[0]["msg"]
-        == f"Value error, Invalid Item Agency. Item Agency is required for {item_location_value}"
+        == f"Value error, Invalid Item Agency for item location: {item_location_value}"
     )
 
 

--- a/tests/test_marc_errors.py
+++ b/tests/test_marc_errors.py
@@ -281,7 +281,7 @@ class TestMarcErrorMonograph:
         assert error.input is None
         assert isinstance(error.ctx, dict)
         assert error.type == "value_error"
-        assert error.msg == "Invalid Item Agency. Item Agency is required for rcmf2"
+        assert error.msg == "Invalid Item Agency for item location: rcmf2"
         assert error.loc_marc == "949$h"
 
     def test_MarcError_literal(self, stub_record):

--- a/tests/test_marc_errors.py
+++ b/tests/test_marc_errors.py
@@ -284,6 +284,71 @@ class TestMarcErrorMonograph:
         assert error.msg == "Invalid Item Agency for item location: rcmf2"
         assert error.loc_marc == "949$h"
 
+    def test_MarcError_item_agency_MAF(self, stub_record):
+        stub_record["949"].delete_subfield("h")
+        stub_record["949"].delete_subfield("l")
+        stub_record["949"].add_subfield("l", "rc2ma")
+        with pytest.raises(ValidationError) as e:
+            RecordModel(leader=stub_record.leader, fields=stub_record.fields)
+        errors = [MarcError(i) for i in e.value.errors()]
+        assert len(e.value.errors()) == 2
+        assert sorted([i["type"] for i in e.value.errors()]) == sorted(
+            [
+                "value_error",
+                "order_item_mismatch",
+            ]
+        )
+        assert sorted([i.loc for i in errors]) == sorted(
+            [
+                ("fields", "949", "item_agency"),
+                ("order_field", "item_location", "item_type"),
+            ]
+        )
+        assert [i.input for i in errors] == [
+            {"order_location": "MAF", "item_location": "rc2ma", "item_type": "55"},
+            None,
+        ]
+        assert sorted([i.msg for i in errors]) == sorted(
+            [
+                "Invalid Item Agency for order location: MAF",
+                "Invalid combination of item_type, order_location and item_location: {'order_location': 'MAF', 'item_location': 'rc2ma', 'item_type': '55'}",
+            ]
+        )
+
+    def test_MarcError_item_agency_multi_item(self, stub_record, stub_evp_item):
+        stub_record["949"].delete_subfield("h")
+        stub_record["949"].delete_subfield("l")
+        stub_record["960"].delete_subfield("t")
+        stub_record["960"].add_subfield("t", "MAL")
+        stub_evp_item.delete_subfield("h")
+        stub_record.add_field(stub_evp_item)
+        with pytest.raises(ValidationError) as e:
+            RecordModel(leader=stub_record.leader, fields=stub_record.fields)
+        errors = [MarcError(i) for i in e.value.errors()]
+        assert len(e.value.errors()) == 2
+        assert sorted([i.type for i in errors]) == sorted(
+            [
+                "value_error",
+                "order_item_mismatch",
+            ]
+        )
+        assert sorted([i.loc for i in errors]) == sorted(
+            [
+                ("fields", "949", "item_agency"),
+                ("order_field", "item_location", "item_type"),
+            ]
+        )
+        assert [i.input for i in errors] == [
+            None,
+            {"order_location": "MAL", "item_location": "rcmf2", "item_type": "55"},
+        ]
+        assert sorted([i.msg for i in errors]) == sorted(
+            [
+                "Invalid Item Agency for item location: rcmf2",
+                "Invalid combination of item_type, order_location and item_location: {'order_location': 'MAL', 'item_location': 'rcmf2', 'item_type': '55'}",
+            ]
+        )
+
     def test_MarcError_literal(self, stub_record):
         stub_record["960"].delete_subfield("t")
         stub_record["960"].add_subfield("t", "foo")
@@ -332,6 +397,7 @@ class TestMarcErrorMonograph:
             == "Invalid indicators. Valid combinations are: [(' ', '4'), ('', '4'), ('0', '0'), ('1', '0')]"
         )
         assert error.loc_marc == "050"
+        assert error.loc == ("fields", "050")
 
     def test_MarcError_extra_fields(self, stub_record):
         record_dict = stub_record.as_dict()

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -99,6 +99,47 @@ class TestValidateMonograph:
             "item_type": "55",
         }
 
+    def test_validate_order_items_no_item_agency_MAL(self, stub_record):
+        stub_record["960"].delete_subfield("t")
+        stub_record["960"].add_subfield("t", "MAL")
+        stub_record["949"].delete_subfield("l")
+        stub_record["949"].delete_subfield("h")
+        stub_record["949"].delete_subfield("t")
+        errors = []
+        with does_not_raise():
+            errors.extend(
+                validate_order_items(
+                    fields=stub_record.as_dict()["fields"],
+                    error_locs=[],
+                )
+            )
+        assert len(errors) == 0
+        assert isinstance(errors, list)
+
+    def test_validate_order_items_no_item_agency_MAF(self, stub_record):
+        stub_record["949"].delete_subfield("l")
+        stub_record["949"].delete_subfield("h")
+        errors = []
+        with does_not_raise():
+            errors.extend(
+                validate_order_items(
+                    fields=stub_record.as_dict()["fields"],
+                    error_locs=[],
+                )
+            )
+        error_types = [str(i["type"]) for i in errors]
+        error_inputs = [i["input"] for i in errors]
+        assert len(errors) == 2
+        assert isinstance(errors, list)
+        assert error_types == [
+            "Invalid combination of item_type, order_location and item_location: {'order_location': 'MAF', 'item_location': None, 'item_type': '55'}",
+            "Invalid Item Agency for order location: MAF",
+        ]
+        assert error_inputs == [
+            {"order_location": "MAF", "item_location": None, "item_type": "55"},
+            None,
+        ]
+
     def test_validate_order_items_no_errors(self, stub_record):
         errors = []
         with does_not_raise():


### PR DESCRIPTION
Added
 - `validate_order_items` now checks it the `item_agency` is valid for the associated `order_location`. This will identify missing `item_agency` values for items with the `item_location` `None` or `rc2ma` that have an `order_location` other than `MAL`
 - additional tests

Fixed
 - `validate_item_agency` after validator for `ItemField` model. `ItemField.item_agency` is now valid if `ItemField.item_location` is `rc2ma` or `None`