### PR TITLE
up-to-date ReCAP call numbers

### DIFF
--- a/record_validator/constants.py
+++ b/record_validator/constants.py
@@ -2,6 +2,9 @@
 
 from enum import Enum
 
+RECAP_CALL_NO_PATTERN = r"^ReCAP 2[3-9]-\d{6}$"
+RECAP_AUX_CALL_NO_PATTERN = r"^ReCAP 2[3-9]-$"
+
 
 class AllFields(Enum):
     """A class to translate a field model to its corresponding MARC tag"""

--- a/record_validator/field_models.py
+++ b/record_validator/field_models.py
@@ -5,6 +5,7 @@ from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 from pydantic import Field, model_validator
 
 from record_validator.base_fields import BaseControlField, BaseDataField
+from record_validator.constants import RECAP_AUX_CALL_NO_PATTERN, RECAP_CALL_NO_PATTERN
 
 
 class AuxBibCallNo(BaseDataField):
@@ -26,7 +27,7 @@ class AuxBibCallNo(BaseDataField):
     call_no: Annotated[
         str,
         Field(
-            pattern=r"^ReCAP 23-$|^ReCAP 24-$|^ReCAP 25-$",
+            pattern=RECAP_AUX_CALL_NO_PATTERN,
             min_length=9,
             max_length=9,
             exclude=True,
@@ -54,7 +55,7 @@ class BibCallNo(BaseDataField):
     call_no: Annotated[
         str,
         Field(
-            pattern=r"^ReCAP 23-\d{6}$|^ReCAP 24-\d{6}$|^ReCAP 25-\d{6}$",
+            pattern=RECAP_CALL_NO_PATTERN,
             min_length=15,
             max_length=15,
             exclude=True,
@@ -308,7 +309,7 @@ class ItemField(BaseDataField):
     item_call_no: Annotated[
         str,
         Field(
-            pattern=r"^ReCAP 23-\d{6}$|^ReCAP 24-\d{6}$|^ReCAP 25-\d{6}$",
+            pattern=RECAP_CALL_NO_PATTERN,
             min_length=15,
             max_length=15,
             examples=["ReCAP 23-000001", "ReCAP 24-100001", "ReCAP 25-222000"],

--- a/record_validator/marc_models.py
+++ b/record_validator/marc_models.py
@@ -2,8 +2,7 @@
 
 from typing import Annotated, Dict, List, Union
 
-from pydantic import BaseModel, ConfigDict, Field
-from pydantic.functional_validators import AfterValidator, BeforeValidator
+from pydantic import AfterValidator, BaseModel, BeforeValidator, ConfigDict, Field
 from pymarc import Field as MarcField
 
 from record_validator.validators import validate_all, validate_leader

--- a/record_validator/utils.py
+++ b/record_validator/utils.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, List, Union
 
 from pymarc import Field as MarcField
 
+from record_validator.constants import RECAP_AUX_CALL_NO_PATTERN
+
 
 def dict2subfield(field: Dict[str, Any], code: str) -> List[Union[str, None]]:
     """Extract subfield values from a MARC represented as a dict."""
@@ -63,7 +65,7 @@ def get_record_type(fields: List[Union[MarcField, Dict[str, Any]]]) -> str:
     phys_desc = list(chain(*[dict2subfield(i, "a") for i in field_list if "300" in i]))
     subjects = list(chain(*[dict2subfield(i, "v") for i in subject_fields]))
 
-    aux_pattern = re.compile(r"^ReCAP 2[345]-$")
+    aux_pattern = re.compile(RECAP_AUX_CALL_NO_PATTERN)
     catalogue = re.compile(r"^[cC]atalogue(s?) [rR]aisonn[eé](s?)")
     multivol = re.compile(r"^(\d+)( v\.| volumes)( :$| ;$|$| $)")
     pamphlet = re.compile(r"^(\d|[0-4][0-9])( p\.| pages)( :$| ;$|$| $)")


### PR DESCRIPTION
 - changed the regex patterns for ReCAP call numbers in order to accommodate most recent date ranges for call numbers
 - added regex patterns to a single location so they do not need to be updated multiple times when changes need to be made